### PR TITLE
feat(config): add JSONC config file support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@opencode-ai/plugin": "1.1.23",
         "bun-pty": "^0.4.5",
+        "jsonc-parser": "^3.3.1",
         "valibot": "^1.2.0",
         "yaml": "^2.8.2",
       },
@@ -46,6 +47,8 @@
     "bun-pty": ["bun-pty@0.4.5", "", {}, "sha512-r8NL1C+z0Dicl9gyi0QV0DAPEBgoKO5CJuecbeS8fpfEkxBHy8XrJ7ibVBS+YRLWjcky3EKl8BY7nY+l4Jv8DQ=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "lefthook": ["lefthook@2.0.15", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.0.15", "lefthook-darwin-x64": "2.0.15", "lefthook-freebsd-arm64": "2.0.15", "lefthook-freebsd-x64": "2.0.15", "lefthook-linux-arm64": "2.0.15", "lefthook-linux-x64": "2.0.15", "lefthook-openbsd-arm64": "2.0.15", "lefthook-openbsd-x64": "2.0.15", "lefthook-windows-arm64": "2.0.15", "lefthook-windows-x64": "2.0.15" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-sl5rePO6UUOLKp6Ci+MMKOc86zicBaPUCvSw2Cq4gCAgTmxpxhIjhz7LOu2ObYerVRPpTq3gvzPTjI71UotjnA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@opencode-ai/plugin": "1.1.23",
     "bun-pty": "^0.4.5",
+    "jsonc-parser": "^3.3.1",
     "valibot": "^1.2.0",
     "yaml": "^2.8.2"
   },

--- a/src/config-loader.test.ts
+++ b/src/config-loader.test.ts
@@ -1,7 +1,10 @@
 // src/config-loader.test.ts
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { type MicodeConfig, type ProviderInfo, validateAgentModels } from "./config-loader";
+import { loadMicodeConfig, type MicodeConfig, type ProviderInfo, validateAgentModels } from "./config-loader";
 
 // Helper to create a minimal ProviderInfo for testing
 function createProvider(id: string, modelIds: string[]): ProviderInfo {
@@ -222,5 +225,53 @@ describe("validateAgentModels", () => {
 
     // Should return { agents: {} } for consistency, not {}
     expect(result).toEqual({ agents: {} });
+  });
+});
+
+describe("JSONC parsing via loadMicodeConfig", () => {
+  let testConfigDir: string;
+
+  beforeEach(() => {
+    testConfigDir = join(tmpdir(), `micode-jsonc-unit-test-${Date.now()}`);
+    mkdirSync(testConfigDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testConfigDir, { recursive: true, force: true });
+  });
+
+  test("parses .jsonc file with comments and trailing commas", async () => {
+    writeFileSync(
+      join(testConfigDir, "micode.jsonc"),
+      `{
+  // Agent configuration
+  "agents": {
+    "commander": {
+      "model": "openai/gpt-4o", // use GPT-4o
+      "temperature": 0.2,
+    },
+  },
+}`,
+    );
+
+    const config = await loadMicodeConfig(testConfigDir);
+
+    expect(config).not.toBeNull();
+    expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
+    expect(config?.agents?.commander?.temperature).toBe(0.2);
+  });
+
+  test("still parses plain .json files (backward compatibility)", async () => {
+    writeFileSync(
+      join(testConfigDir, "micode.json"),
+      JSON.stringify({
+        agents: { commander: { model: "openai/gpt-4o" } },
+      }),
+    );
+
+    const config = await loadMicodeConfig(testConfigDir);
+
+    expect(config).not.toBeNull();
+    expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
   });
 });

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { AgentConfig } from "@opencode-ai/sdk";
-import { parse as parseJsonc } from "jsonc-parser";
+import { type ParseError, parse as parseJsonc } from "jsonc-parser";
 
 // Minimal type for provider validation - only what we need
 export interface ProviderInfo {
@@ -26,7 +26,12 @@ interface OpencodeConfig {
  * Uses the same options as OpenCode's own parser.
  */
 function parseConfigJson(content: string): unknown {
-  return parseJsonc(content, undefined, { allowTrailingComma: true });
+  const errors: ParseError[] = [];
+  const result = parseJsonc(content, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    throw new Error(`Invalid JSON/JSONC: ${errors.length} parse error(s)`);
+  }
+  return result;
 }
 
 /**

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -1,10 +1,11 @@
 // src/config-loader.ts
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { AgentConfig } from "@opencode-ai/sdk";
+import { parse as parseJsonc } from "jsonc-parser";
 
 // Minimal type for provider validation - only what we need
 export interface ProviderInfo {
@@ -21,23 +22,70 @@ interface OpencodeConfig {
 }
 
 /**
- * Load opencode.json config file (synchronous)
- * Returns the parsed config or null if unavailable
+ * Parse a JSON or JSONC string, supporting comments and trailing commas.
+ * Uses the same options as OpenCode's own parser.
  */
-function loadOpencodeConfig(configDir?: string): OpencodeConfig | null {
-  const baseDir = configDir ?? join(homedir(), ".config", "opencode");
+function parseConfigJson(content: string): unknown {
+  return parseJsonc(content, undefined, { allowTrailingComma: true });
+}
+
+/**
+ * Resolve a config file path, preferring .jsonc over .json (synchronous).
+ * Returns the path to the first file found, or null if neither exists.
+ */
+function resolveConfigFileSync(baseDir: string, baseName: string): string | null {
+  const jsoncPath = join(baseDir, `${baseName}.jsonc`);
+  if (existsSync(jsoncPath)) {
+    return jsoncPath;
+  }
+
+  const jsonPath = join(baseDir, `${baseName}.json`);
+  if (existsSync(jsonPath)) {
+    return jsonPath;
+  }
+
+  return null;
+}
+
+/**
+ * Read a config file, preferring .jsonc over .json (async).
+ * Returns the file content string, or null if neither file exists.
+ */
+async function readConfigFileAsync(baseDir: string, baseName: string): Promise<string | null> {
+  // Try .jsonc first
+  try {
+    return await readFile(join(baseDir, `${baseName}.jsonc`), "utf-8");
+  } catch {
+    // .jsonc not found, try .json
+  }
 
   try {
-    const configPath = join(baseDir, "opencode.json");
-    const content = readFileSync(configPath, "utf-8");
-    return JSON.parse(content) as OpencodeConfig;
+    return await readFile(join(baseDir, `${baseName}.json`), "utf-8");
   } catch {
     return null;
   }
 }
 
 /**
- * Load available models from opencode.json config file (synchronous)
+ * Load opencode.json/opencode.jsonc config file (synchronous)
+ * Returns the parsed config or null if unavailable
+ */
+function loadOpencodeConfig(configDir?: string): OpencodeConfig | null {
+  const baseDir = configDir ?? join(homedir(), ".config", "opencode");
+
+  try {
+    const configPath = resolveConfigFileSync(baseDir, "opencode");
+    if (!configPath) return null;
+
+    const content = readFileSync(configPath, "utf-8");
+    return parseConfigJson(content) as OpencodeConfig;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load available models from opencode.json/opencode.jsonc config file (synchronous)
  * Returns a Set of "provider/model" strings
  */
 export function loadAvailableModels(configDir?: string): Set<string> {
@@ -58,7 +106,7 @@ export function loadAvailableModels(configDir?: string): Set<string> {
 }
 
 /**
- * Load the default model from opencode.json config file (synchronous)
+ * Load the default model from opencode.json/opencode.jsonc config file (synchronous)
  * Returns the model string in "provider/model" format or null if not set
  */
 export function loadDefaultModel(configDir?: string): string | null {
@@ -90,17 +138,18 @@ export interface MicodeConfig {
 }
 
 /**
- * Load micode.json from ~/.config/opencode/micode.json
- * Returns null if file doesn't exist or is invalid JSON
+ * Load micode.json/micode.jsonc from ~/.config/opencode/
+ * Returns null if file doesn't exist or is invalid
  * @param configDir - Optional override for config directory (for testing)
  */
 export async function loadMicodeConfig(configDir?: string): Promise<MicodeConfig | null> {
   const baseDir = configDir ?? join(homedir(), ".config", "opencode");
-  const configPath = join(baseDir, "micode.json");
 
   try {
-    const content = await readFile(configPath, "utf-8");
-    const parsed = JSON.parse(content) as Record<string, unknown>;
+    const content = await readConfigFileAsync(baseDir, "micode");
+    if (!content) return null;
+
+    const parsed = parseConfigJson(content) as Record<string, unknown>;
 
     const result: MicodeConfig = {};
 
@@ -166,7 +215,7 @@ export async function loadMicodeConfig(configDir?: string): Promise<MicodeConfig
 }
 
 /**
- * Load model context limits from opencode.json
+ * Load model context limits from opencode.json/opencode.jsonc
  * Returns a Map of "provider/model" -> context limit (tokens)
  */
 export function loadModelContextLimits(configDir?: string): Map<string, number> {
@@ -174,9 +223,11 @@ export function loadModelContextLimits(configDir?: string): Map<string, number> 
   const baseDir = configDir ?? join(homedir(), ".config", "opencode");
 
   try {
-    const configPath = join(baseDir, "opencode.json");
+    const configPath = resolveConfigFileSync(baseDir, "opencode");
+    if (!configPath) return limits;
+
     const content = readFileSync(configPath, "utf-8");
-    const config = JSON.parse(content) as {
+    const config = parseConfigJson(content) as {
       provider?: Record<string, { models?: Record<string, { limit?: { context?: number } }> }>;
     };
 

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -4,7 +4,13 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { loadMicodeConfig, loadModelContextLimits, mergeAgentConfigs } from "../src/config-loader";
+import {
+  loadAvailableModels,
+  loadDefaultModel,
+  loadMicodeConfig,
+  loadModelContextLimits,
+  mergeAgentConfigs,
+} from "../src/config-loader";
 import { DEFAULT_MODEL } from "../src/utils/config";
 
 describe("config-loader", () => {
@@ -47,7 +53,7 @@ describe("config-loader", () => {
 
   it("should return null for invalid JSON", async () => {
     const configPath = join(testConfigDir, "micode.json");
-    writeFileSync(configPath, "{ invalid json }");
+    writeFileSync(configPath, "not json at all }{][");
 
     const config = await loadMicodeConfig(testConfigDir);
     expect(config).toBeNull();
@@ -551,5 +557,320 @@ describe("loadMicodeConfig - fragments", () => {
     expect(config?.fragments?.brainstormer).toEqual(["valid array"]);
     expect(config?.fragments?.planner).toBeUndefined();
     expect(config?.fragments?.implementer).toBeUndefined();
+  });
+});
+
+describe("JSONC parsing support", () => {
+  let testConfigDir: string;
+
+  beforeEach(() => {
+    testConfigDir = join(tmpdir(), `micode-jsonc-test-${Date.now()}`);
+    mkdirSync(testConfigDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testConfigDir, { recursive: true, force: true });
+  });
+
+  describe("loadMicodeConfig with JSONC", () => {
+    it("should parse micode.jsonc with line comments", async () => {
+      const configPath = join(testConfigDir, "micode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  // This is a line comment
+  "agents": {
+    "commander": { "model": "openai/gpt-4o" } // inline comment
+  }
+}`,
+      );
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config).not.toBeNull();
+      expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
+    });
+
+    it("should parse micode.jsonc with block comments", async () => {
+      const configPath = join(testConfigDir, "micode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  /* Block comment explaining config */
+  "agents": {
+    "brainstormer": {
+      /* Use a creative model */
+      "model": "openai/gpt-4o",
+      "temperature": 0.8
+    }
+  }
+}`,
+      );
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config).not.toBeNull();
+      expect(config?.agents?.brainstormer?.model).toBe("openai/gpt-4o");
+      expect(config?.agents?.brainstormer?.temperature).toBe(0.8);
+    });
+
+    it("should parse micode.jsonc with trailing commas", async () => {
+      const configPath = join(testConfigDir, "micode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  "agents": {
+    "commander": {
+      "model": "openai/gpt-4o",
+      "temperature": 0.3,
+    },
+  },
+  "compactionThreshold": 0.5,
+}`,
+      );
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config).not.toBeNull();
+      expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
+      expect(config?.agents?.commander?.temperature).toBe(0.3);
+      expect(config?.compactionThreshold).toBe(0.5);
+    });
+
+    it("should prefer micode.jsonc over micode.json when both exist", async () => {
+      // Write .json with one value
+      writeFileSync(
+        join(testConfigDir, "micode.json"),
+        JSON.stringify({
+          agents: { commander: { model: "openai/gpt-3.5" } },
+        }),
+      );
+      // Write .jsonc with a different value
+      writeFileSync(
+        join(testConfigDir, "micode.jsonc"),
+        `{
+  "agents": {
+    "commander": { "model": "openai/gpt-4o" }
+  }
+}`,
+      );
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config).not.toBeNull();
+      // Should use the .jsonc value, not the .json value
+      expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
+    });
+
+    it("should fall back to micode.json when micode.jsonc does not exist", async () => {
+      writeFileSync(
+        join(testConfigDir, "micode.json"),
+        JSON.stringify({
+          agents: { commander: { model: "openai/gpt-4o" } },
+        }),
+      );
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config).not.toBeNull();
+      expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
+    });
+
+    it("should return null when neither micode.jsonc nor micode.json exists", async () => {
+      const config = await loadMicodeConfig(testConfigDir);
+      expect(config).toBeNull();
+    });
+
+    it("should parse micode.jsonc with all comment types combined", async () => {
+      const configPath = join(testConfigDir, "micode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  // Line comment
+  /* Block comment */
+  "agents": {
+    "commander": {
+      "model": "openai/gpt-4o", // trailing comma + inline comment
+      "temperature": 0.3,
+    },
+  },
+  "features": {
+    "mindmodelInjection": true, // enable mindmodel
+  },
+  "compactionThreshold": 0.4,
+}`,
+      );
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config).not.toBeNull();
+      expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
+      expect(config?.agents?.commander?.temperature).toBe(0.3);
+      expect(config?.features?.mindmodelInjection).toBe(true);
+      expect(config?.compactionThreshold).toBe(0.4);
+    });
+  });
+
+  describe("loadModelContextLimits with JSONC", () => {
+    it("should parse opencode.jsonc with comments for context limits", () => {
+      const configPath = join(testConfigDir, "opencode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  // Provider configuration
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-4o": {
+          "limit": { "context": 128000 } // 128k context window
+        }
+      }
+    }
+  }
+}`,
+      );
+
+      const limits = loadModelContextLimits(testConfigDir);
+
+      expect(limits.get("openai/gpt-4o")).toBe(128000);
+    });
+
+    it("should parse opencode.jsonc with trailing commas for context limits", () => {
+      const configPath = join(testConfigDir, "opencode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-4o": {
+          "limit": { "context": 128000, },
+        },
+      },
+    },
+  },
+}`,
+      );
+
+      const limits = loadModelContextLimits(testConfigDir);
+
+      expect(limits.get("openai/gpt-4o")).toBe(128000);
+    });
+
+    it("should prefer opencode.jsonc over opencode.json for context limits", () => {
+      // .json has 64000
+      writeFileSync(
+        join(testConfigDir, "opencode.json"),
+        JSON.stringify({
+          provider: {
+            openai: { models: { "gpt-4o": { limit: { context: 64000 } } } },
+          },
+        }),
+      );
+      // .jsonc has 128000
+      writeFileSync(
+        join(testConfigDir, "opencode.jsonc"),
+        `{
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-4o": { "limit": { "context": 128000 } }
+      }
+    }
+  }
+}`,
+      );
+
+      const limits = loadModelContextLimits(testConfigDir);
+
+      // Should use .jsonc value
+      expect(limits.get("openai/gpt-4o")).toBe(128000);
+    });
+
+    it("should fall back to opencode.json for context limits when .jsonc missing", () => {
+      writeFileSync(
+        join(testConfigDir, "opencode.json"),
+        JSON.stringify({
+          provider: {
+            openai: { models: { "gpt-4o": { limit: { context: 128000 } } } },
+          },
+        }),
+      );
+
+      const limits = loadModelContextLimits(testConfigDir);
+
+      expect(limits.get("openai/gpt-4o")).toBe(128000);
+    });
+
+    it("should return empty map when neither opencode.jsonc nor opencode.json exists", () => {
+      const limits = loadModelContextLimits(testConfigDir);
+
+      expect(limits.size).toBe(0);
+    });
+  });
+
+  describe("loadAvailableModels with JSONC", () => {
+    it("should load models from opencode.jsonc", () => {
+      const configPath = join(testConfigDir, "opencode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  // Model configuration
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-4o": {}, // latest model
+      },
+    },
+  },
+}`,
+      );
+
+      const models = loadAvailableModels(testConfigDir);
+
+      expect(models.has("openai/gpt-4o")).toBe(true);
+    });
+
+    it("should prefer opencode.jsonc over opencode.json for available models", () => {
+      writeFileSync(
+        join(testConfigDir, "opencode.json"),
+        JSON.stringify({
+          provider: { openai: { models: { "gpt-3.5": {} } } },
+        }),
+      );
+      writeFileSync(
+        join(testConfigDir, "opencode.jsonc"),
+        `{
+  "provider": {
+    "openai": {
+      "models": { "gpt-4o": {} }
+    }
+  }
+}`,
+      );
+
+      const models = loadAvailableModels(testConfigDir);
+
+      // Should have model from .jsonc, not .json
+      expect(models.has("openai/gpt-4o")).toBe(true);
+      expect(models.has("openai/gpt-3.5")).toBe(false);
+    });
+  });
+
+  describe("loadDefaultModel with JSONC", () => {
+    it("should load default model from opencode.jsonc", () => {
+      const configPath = join(testConfigDir, "opencode.jsonc");
+      writeFileSync(
+        configPath,
+        `{
+  // Use GPT-4o as default
+  "model": "openai/gpt-4o",
+}`,
+      );
+
+      const model = loadDefaultModel(testConfigDir);
+
+      expect(model).toBe("openai/gpt-4o");
+    });
   });
 });


### PR DESCRIPTION
Support opencode.jsonc and micode.jsonc config files with comments and trailing commas, matching OpenCode's own JSONC parsing behavior.

- Add jsonc-parser dependency (same library OpenCode uses)
- Try .jsonc files first, fall back to .json for backward compatibility
- Update loadOpencodeConfig, loadModelContextLimits, loadMicodeConfig
- Add 17 new tests covering JSONC parsing, file precedence, fallback