### PR TITLE
feat(config): allow thinking/reasoning config per agent via micode.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Maintain context across sessions with structured compaction. Run `/ledger` to cr
 
 ## Hooks
 
-- **Think Mode** - Keywords like "think hard" enable 32k token thinking budget
+- **Think Mode** - Keywords like "think hard" enable 128k token thinking budget
 - **Ledger Loader** - Injects continuity ledger into system prompt
 - **Auto-Compact** - At 50% context usage, automatically summarizes session to reduce context
 - **File Ops Tracker** - Tracks read/write/edit for deterministic logging
@@ -106,11 +106,15 @@ All micode agents will use this model automatically.
 
 Create `~/.config/opencode/micode.json` for micode-specific settings:
 
-```json
+```jsonc
 {
   "agents": {
     "brainstormer": { "model": "openai/gpt-4o", "temperature": 0.8 },
-    "commander": { "maxTokens": 8192 }
+    "commander": {
+      "maxTokens": 8192,
+      // Configure reasoning effort per agent
+      "thinking": { "type": "enabled", "budgetTokens": 100000 }
+    }
   },
   "features": {
     "mindmodelInjection": true
@@ -122,11 +126,13 @@ Create `~/.config/opencode/micode.json` for micode-specific settings:
 }
 ```
 
+> **Note:** Both `.json` and `.jsonc` formats are supported. JSONC allows comments and trailing commas.
+
 #### Options
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `agents` | object | Per-agent overrides (model, temperature, maxTokens) |
+| `agents` | object | Per-agent overrides (model, temperature, maxTokens, thinking) |
 | `features.mindmodelInjection` | boolean | Enable mindmodel context injection |
 | `compactionThreshold` | number | Context usage threshold (0-1) for auto-compaction. Default: 0.5 |
 | `fragments` | object | Additional prompt fragments per agent |

--- a/src/agents/commander.ts
+++ b/src/agents/commander.ts
@@ -250,7 +250,7 @@ export const primaryAgent: AgentConfig = {
   temperature: 0.2,
   thinking: {
     type: "enabled",
-    budgetTokens: 32000,
+    budgetTokens: 64000,
   },
   maxTokens: 64000,
   tools: {

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -120,7 +120,7 @@ export function loadDefaultModel(configDir?: string): string | null {
 }
 
 // Safe properties that users can override
-const SAFE_AGENT_PROPERTIES = ["model", "temperature", "maxTokens"] as const;
+const SAFE_AGENT_PROPERTIES = ["model", "temperature", "maxTokens", "thinking"] as const;
 
 // Built-in OpenCode models that don't require validation (always available)
 const BUILTIN_MODELS = new Set(["opencode/big-pickle"]);
@@ -129,6 +129,10 @@ export interface AgentOverride {
   model?: string;
   temperature?: number;
   maxTokens?: number;
+  thinking?: {
+    type: string;
+    budgetTokens: number;
+  };
 }
 
 export interface MicodeFeatures {

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,7 +313,7 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
           ...output.options,
           thinking: {
             type: "enabled",
-            budgetTokens: 32000,
+            budgetTokens: 128000,
           },
         };
       }


### PR DESCRIPTION
## Summary

- Users can now configure `thinking` per agent in `micode.json` (was silently dropped before)
- Commander base thinking budget bumped from 32k → 64k tokens
- Think mode hook ("think hard" keywords) bumped from 32k → 128k tokens

### Example config

```jsonc
{
  "agents": {
    "commander": {
      "thinking": { "type": "enabled", "budgetTokens": 100000 }
    },
    "planner": {
      "thinking": { "type": "enabled", "budgetTokens": 64000 }
    }
  }
}
```

Fixes #21 — thanks @flipch for the suggestion!