### PR TITLE
fix: preserve agent step limits

### DIFF
--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -129,6 +129,8 @@ export interface AgentOverride {
   readonly model?: string;
   readonly temperature?: number;
   readonly maxTokens?: number;
+  readonly steps?: number;
+  readonly maxSteps?: number;
   readonly thinking?: {
     readonly type: string;
     readonly budgetTokens: number;

--- a/src/config-schemas.ts
+++ b/src/config-schemas.ts
@@ -13,6 +13,8 @@ const AgentOverrideSchema = v.object({
   model: v.optional(v.string()),
   temperature: v.optional(v.number()),
   maxTokens: v.optional(v.number()),
+  steps: v.optional(v.number()),
+  maxSteps: v.optional(v.number()),
   thinking: v.optional(ThinkingSchema),
 });
 
@@ -38,7 +40,7 @@ export const RawMicodeConfigSchema = v.object({
 });
 
 // Safe properties that users can override in agent configs
-const SAFE_AGENT_PROPERTIES = ["model", "temperature", "maxTokens", "thinking"] as const;
+const SAFE_AGENT_PROPERTIES = ["model", "temperature", "maxTokens", "steps", "maxSteps", "thinking"] as const;
 
 /**
  * Validate and sanitize an individual agent override.

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export function mergePluginAgents(
 ): Record<string, AgentConfig> {
   return Object.fromEntries(
     Object.entries(pluginAgents).map(([name, agent]) => [name, mergePluginAgentConfig(existingAgents?.[name], agent)]),
-  ) as Record<string, AgentConfig>;
+  );
 }
 
 // eslint-disable-next-line max-lines-per-function

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "@opencode-ai/plugin";
-import type { McpLocalConfig } from "@opencode-ai/sdk";
+import type { AgentConfig, McpLocalConfig } from "@opencode-ai/sdk";
 
 import { agents, PRIMARY_AGENT_NAME } from "@/agents";
 import { loadMicodeConfig, loadModelContextLimits, mergeAgentConfigs } from "@/config-loader";
@@ -105,6 +105,22 @@ function extractTextFromParts(parts: Array<{ type: string; text?: string }>): st
     .filter((p) => p.type === "text" && "text" in p)
     .map((p) => (p as { text: string }).text)
     .join("");
+}
+
+export function mergePluginAgentConfig(existingAgent: AgentConfig | undefined, pluginAgent: AgentConfig): AgentConfig {
+  return {
+    ...existingAgent,
+    ...pluginAgent,
+  };
+}
+
+export function mergePluginAgents(
+  existingAgents: Record<string, AgentConfig | undefined> | undefined,
+  pluginAgents: Record<string, AgentConfig>,
+): Record<string, AgentConfig> {
+  return Object.fromEntries(
+    Object.entries(pluginAgents).map(([name, agent]) => [name, mergePluginAgentConfig(existingAgents?.[name], agent)]),
+  ) as Record<string, AgentConfig>;
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -299,6 +315,7 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
 
       // Merge user config overrides into plugin agents
       const mergedAgents = mergeAgentConfigs(agents, userConfig);
+      const pluginAgents = mergePluginAgents(config.agent, mergedAgents);
 
       // Add our agents - our agents override OpenCode defaults, demote built-in build/plan to subagent
       config.agent = {
@@ -307,9 +324,9 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
         plan: { ...config.agent?.plan, mode: "subagent" },
         triage: { ...config.agent?.triage, mode: "subagent" },
         docs: { ...config.agent?.docs, mode: "subagent" },
-        // Our agents override - spread these LAST so they take precedence
-        ...Object.fromEntries(Object.entries(mergedAgents).filter(([k]) => k !== PRIMARY_AGENT_NAME)),
-        [PRIMARY_AGENT_NAME]: mergedAgents[PRIMARY_AGENT_NAME],
+        // Our agents override OpenCode defaults while preserving user fields like steps/maxSteps.
+        ...Object.fromEntries(Object.entries(pluginAgents).filter(([k]) => k !== PRIMARY_AGENT_NAME)),
+        [PRIMARY_AGENT_NAME]: pluginAgents[PRIMARY_AGENT_NAME],
       };
 
       // Add MCP servers (plugin servers override defaults)

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -71,7 +71,7 @@ describe("config-loader", () => {
     expect(config?.agents).toEqual({});
   });
 
-  it("should only allow safe properties (model, temperature, maxTokens)", async () => {
+  it("should only allow safe properties for agent overrides", async () => {
     const configPath = join(testConfigDir, "micode.json");
     writeFileSync(
       configPath,
@@ -81,6 +81,8 @@ describe("config-loader", () => {
             model: "openai/gpt-4o",
             temperature: 0.3,
             maxTokens: 8000,
+            steps: 15,
+            maxSteps: 20,
             prompt: "MALICIOUS PROMPT", // Should be filtered
             tools: { bash: true }, // Should be filtered
           },
@@ -94,6 +96,8 @@ describe("config-loader", () => {
     expect(config?.agents?.commander?.model).toBe("openai/gpt-4o");
     expect(config?.agents?.commander?.temperature).toBe(0.3);
     expect(config?.agents?.commander?.maxTokens).toBe(8000);
+    expect(config?.agents?.commander?.steps).toBe(15);
+    expect(config?.agents?.commander?.maxSteps).toBe(20);
     // These should be filtered out
     expect((config?.agents?.commander as Record<string, unknown>)?.prompt).toBeUndefined();
     expect((config?.agents?.commander as Record<string, unknown>)?.tools).toBeUndefined();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,6 +2,36 @@
 import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 
+import { mergePluginAgents } from "../src/index";
+
+describe("mergePluginAgents", () => {
+  it("preserves user iteration limits from existing OpenCode agent config", () => {
+    const merged = mergePluginAgents(
+      {
+        planner: {
+          model: "user/model",
+          mode: "primary",
+          steps: 15,
+          maxSteps: 20,
+        },
+      },
+      {
+        planner: {
+          model: "plugin/model",
+          mode: "subagent",
+          prompt: "Planner prompt",
+        },
+      },
+    );
+
+    expect(merged.planner.model).toBe("plugin/model");
+    expect(merged.planner.mode).toBe("subagent");
+    expect(merged.planner.prompt).toBe("Planner prompt");
+    expect(merged.planner.steps).toBe(15);
+    expect(merged.planner.maxSteps).toBe(20);
+  });
+});
+
 describe("index.ts constraint-reviewer integration", () => {
   it("should import createConstraintReviewerHook", async () => {
     const source = await readFile("src/index.ts", "utf-8");


### PR DESCRIPTION
## Summary
- preserve existing OpenCode agent fields such as `steps`/`maxSteps` when micode overlays plugin agents
- allow `steps` and `maxSteps` through sanitized `micode.json` agent overrides
- add regression coverage for both config loading and plugin-agent merging

## Root cause
micode built the plugin agent map and then spread those agents directly over `config.agent`. That replaced the existing OpenCode agent object, so fields configured outside the plugin overlay, including iteration limits such as `steps`, were silently dropped.

## Validation
- `bun run check`
- `bun run build`
- `git diff --check`

Closes #53

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves user-configured agent iteration limits (`steps`, `maxSteps`) when plugin agents overlay OpenCode defaults, and allows these fields in sanitized `micode.json` overrides.

- **Bug Fixes**
  - Merge plugin agents with existing `config.agent` via `mergePluginAgents` to keep fields like `steps`/`maxSteps`.
  - Allow `steps` and `maxSteps` in `AgentOverride` schema and safe properties.
  - Add regression tests for config loading and agent merge behavior.

- **Refactors**
  - Remove redundant type assertions around `Object.fromEntries` to satisfy `typescript-eslint` 8.65 rules.

<sup>Written for commit 664e196d5bf136332310e5188e3680163ed49128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/vtemian/micode/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

