### PR TITLE
chore: switch dependabot to the bun ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` declares `package-ecosystem: npm`, but this repo is Bun with a committed `bun.lock`. The npm ecosystem rewrites `package.json` only, so every dependency PR arrives with a stale lockfile and the quality gate fails before it runs a single check:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

This is not intermittent. It hits every npm PR: #80, #83, #84 are all sitting on this exact failure, and it will hit every future one.

## Fix

Switch the ecosystem to `bun`, which updates `bun.lock` alongside `package.json`. Requires Bun >= 1.1.39; CI runs `bun-version: latest`.

## Tradeoff

The `bun` ecosystem supports version updates but not security updates. Dependabot will stop opening security-only PRs for this repo. The alternative is keeping PRs that never pass CI, so the exchange looks worth making, but it is a real loss worth naming.

The `github-actions` entry is untouched: it already works.