### PR TITLE
test: assert on logs that tests deliberately trigger

### DIFF
--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -14,6 +14,7 @@ import {
   validateAgentModels,
 } from "../src/config-loader";
 import { DEFAULT_MODEL } from "../src/utils/config";
+import { captureLogs, type LogCapture } from "./helpers/log-capture";
 
 describe("config-loader", () => {
   let testConfigDir: string;
@@ -882,6 +883,16 @@ describe("JSONC parsing support", () => {
 });
 
 describe("validateAgentModels", () => {
+  let logs: LogCapture;
+
+  beforeEach(() => {
+    logs = captureLogs();
+  });
+
+  afterEach(() => {
+    logs.restore();
+  });
+
   function createProvider(id: string, modelIds: string[]): ProviderInfo {
     const models: Record<string, unknown> = {};
     for (const modelId of modelIds) {
@@ -889,6 +900,9 @@ describe("validateAgentModels", () => {
     }
     return { id, models };
   }
+
+  const notFound = (model: string, agent: string): string =>
+    `[config-loader] Model "${model}" not found for agent "${agent}". Using default model.`;
 
   it("returns config unchanged when all models are valid", () => {
     const userConfig = {
@@ -921,6 +935,7 @@ describe("validateAgentModels", () => {
     const result = validateAgentModels(userConfig, providers);
 
     expect(result.agents?.commander?.model).toBeUndefined();
+    expect(logs.warn).toEqual([notFound("nonexistent/gpt-4", "commander")]);
   });
 
   it("removes model override when model does not exist in provider", () => {
@@ -935,6 +950,7 @@ describe("validateAgentModels", () => {
     const result = validateAgentModels(userConfig, providers);
 
     expect(result.agents?.commander?.model).toBeUndefined();
+    expect(logs.warn).toEqual([notFound("openai/nonexistent-model", "commander")]);
   });
 
   it("preserves other properties when model is invalid", () => {
@@ -955,6 +971,7 @@ describe("validateAgentModels", () => {
     expect(result.agents?.commander?.model).toBeUndefined();
     expect(result.agents?.commander?.temperature).toBe(0.7);
     expect(result.agents?.commander?.maxTokens).toBe(4000);
+    expect(logs.warn).toEqual([notFound("nonexistent/model", "commander")]);
   });
 
   it("handles config with no agents", () => {
@@ -1031,6 +1048,7 @@ describe("validateAgentModels", () => {
     expect(result.agents?.brainstormer?.model).toBeUndefined();
     expect(result.agents?.planner?.model).toBeUndefined();
     expect(result.agents?.reviewer?.model).toBe("anthropic/claude-3");
+    expect(logs.warn).toEqual([notFound("fake/model", "brainstormer"), notFound("openai/fake-model", "planner")]);
   });
 
   it("removes empty string model", () => {
@@ -1046,6 +1064,7 @@ describe("validateAgentModels", () => {
 
     expect(result.agents?.commander?.model).toBeUndefined();
     expect(result.agents?.commander?.temperature).toBe(0.5);
+    expect(logs.warn).toEqual(['[config-loader] Empty model for agent "commander". Using default model.']);
   });
 
   it("removes model string without slash (malformed)", () => {
@@ -1060,6 +1079,7 @@ describe("validateAgentModels", () => {
     const result = validateAgentModels(userConfig, providers);
 
     expect(result.agents?.commander?.model).toBeUndefined();
+    expect(logs.warn).toEqual([notFound("gpt-4-no-provider", "commander")]);
   });
 
   it("handles model with multiple slashes in model ID", () => {
@@ -1088,5 +1108,6 @@ describe("validateAgentModels", () => {
     const result = validateAgentModels(userConfig, providers);
 
     expect(result).toEqual({ agents: {} });
+    expect(logs.warn).toEqual([notFound("invalid/model", "commander")]);
   });
 });

--- a/tests/helpers/log-capture.ts
+++ b/tests/helpers/log-capture.ts
@@ -1,0 +1,47 @@
+// tests/helpers/log-capture.ts
+import { spyOn } from "bun:test";
+
+/**
+ * Console output collected while a test runs.
+ *
+ * Tests that intentionally drive production code down a logging path use this
+ * to keep the reporter output pristine while still asserting on what was
+ * logged. Multi-argument calls are joined with a single space.
+ */
+export interface LogCapture {
+  readonly info: string[];
+  readonly warn: string[];
+  readonly error: string[];
+  restore: () => void;
+}
+
+const format = (args: unknown[]): string => args.map((arg) => String(arg)).join(" ");
+
+export function captureLogs(): LogCapture {
+  const info: string[] = [];
+  const warn: string[] = [];
+  const error: string[] = [];
+
+  const spies = [
+    spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      info.push(format(args));
+    }),
+    spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warn.push(format(args));
+    }),
+    spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      error.push(format(args));
+    }),
+  ];
+
+  return {
+    info,
+    warn,
+    error,
+    restore: () => {
+      for (const spy of spies) {
+        spy.mockRestore();
+      }
+    },
+  };
+}

--- a/tests/hooks/constraint-reviewer.test.ts
+++ b/tests/hooks/constraint-reviewer.test.ts
@@ -4,14 +4,19 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { captureLogs, type LogCapture } from "../helpers/log-capture";
+
 describe("createConstraintReviewerHook", () => {
   let testDir: string;
+  let logs: LogCapture;
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), "constraint-reviewer-test-"));
+    logs = captureLogs();
   });
 
   afterEach(() => {
+    logs.restore();
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -303,6 +308,7 @@ categories:
     // Review should have been skipped due to override
     expect(reviewCalled).toBe(false);
     expect(output.output).toBe("bad code that would normally be blocked");
+    expect(logs.info).toEqual(["[mindmodel] Override activated: testing exception case"]);
   });
 
   it("should reset override after one use", async () => {
@@ -348,6 +354,7 @@ categories:
     );
 
     expect(reviewCallCount).toBe(1);
+    expect(logs.info).toEqual(["[mindmodel] Override activated: one-time exception"]);
   });
 
   it("should skip review when args has no file_path", async () => {
@@ -395,6 +402,7 @@ categories:
 
     // Output should be unchanged (graceful degradation)
     expect(output.output).toBe("some code");
+    expect(logs.warn).toEqual(["[mindmodel] Review failed: Review service unavailable"]);
   });
 
   it("should track retry count per file, not per session", async () => {

--- a/tests/mindmodel/loader.test.ts
+++ b/tests/mindmodel/loader.test.ts
@@ -5,15 +5,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { loadExamples, loadMindmodel } from "../../src/mindmodel/loader";
+import { captureLogs, type LogCapture } from "../helpers/log-capture";
 
 describe("mindmodel loader", () => {
   let testDir: string;
+  let logs: LogCapture;
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), "mindmodel-loader-test-"));
+    logs = captureLogs();
   });
 
   afterEach(() => {
+    logs.restore();
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -94,6 +98,9 @@ categories: []
 
     const mindmodel = await loadMindmodel(testDir);
     expect(mindmodel).toBeNull();
+    expect(logs.warn).toEqual([
+      '[mindmodel] Failed to load manifest: Invalid key: Expected "version" but received undefined',
+    ]);
   });
 
   it("should skip gracefully when loading examples with non-existent category path", async () => {
@@ -122,5 +129,6 @@ categories:
     // Should only return the existing file, skipping the missing one
     expect(examples).toHaveLength(1);
     expect(examples[0].path).toBe("components/button.md");
+    expect(logs.warn).toEqual(["[mindmodel] Failed to load example: components/missing.md"]);
   });
 });


### PR DESCRIPTION
## Problem

Thirteen log lines leaked into the test reporter on every run:

```
[config-loader] Model "nonexistent/gpt-4" not found for agent "commander". Using default model.   (x8)
[mindmodel] Failed to load manifest: Invalid key: Expected "version" but received undefined       (x2)
[mindmodel] Override activated: one-time exception                                                (x3)
```

None of it indicates a failure. Each line comes from a test deliberately driving production code down a warning path. But noise in a passing run is how a real regression goes unnoticed, and the project rule is explicit: if a test intentionally triggers an error, the output must be captured and validated.

## Fix

A shared `captureLogs()` helper in `tests/helpers/log-capture.ts` collects `console.log/warn/error` into three arrays and restores the spies afterwards.

The important part is that capturing is paired with asserting. Silencing alone would keep the reporter clean while hiding regressions in what the code actually reports, so every capture site gets an equality check on the collected output:

```ts
expect(logs.warn).toEqual([notFound("nonexistent/gpt-4", "commander")]);
```

Twelve new assertions across three files. `toEqual` on the whole array rather than `toContain` means an unexpected extra log line also fails.

## Verification

- Stray log lines in full-suite output: **13 -> 0**
- **450 tests pass**, 0 fail; expect() calls 876 -> 888
- Mutation-checked: changing an expected message to a wrong value fails the test, confirming the assertions bind rather than passing vacuously

Pre-existing and left alone: biome's `useOptionalChain` warning on `src/tools/pty/manager.ts:151`, which is a lint warning rather than test output and is flagged as an unsafe fix.