### PR TITLE
feat: make the bundled context7 server optional (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Create `~/.config/opencode/micode.json` for micode-specific settings:
     }
   },
   "features": {
-    "mindmodelInjection": true
+    "mindmodelInjection": true,
+    "context7": false
   },
   "compactionThreshold": 0.5,
   "fragments": {
@@ -134,7 +135,8 @@ Create `~/.config/opencode/micode.json` for micode-specific settings:
 |--------|------|-------------|
 | `agents` | object | Per-agent overrides (model, temperature, maxTokens, thinking) |
 | `features.mindmodelInjection` | boolean | Enable mindmodel context injection |
-| `compactionThreshold` | number | Context usage threshold (0-1) for auto-compaction. Default: 0.5 |
+| `features.context7` | boolean | Register the bundled context7 MCP server. Set `false` when it already comes from another tool or proxy. Default: `true` |
+| `compactionThreshold` | number | Context usage threshold (0-1) for auto-compaction. Default: 0.7 |
 | `fragments` | object | Additional prompt fragments per agent |
 
 #### Model Resolution Priority

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -139,6 +139,8 @@ export interface AgentOverride {
 
 export interface MicodeFeatures {
   readonly mindmodelInjection?: boolean;
+  /** Set false when context7 is already provided by another tool or proxy. */
+  readonly context7?: boolean;
 }
 
 export interface MicodeConfig {

--- a/src/config-schemas.ts
+++ b/src/config-schemas.ts
@@ -20,6 +20,8 @@ const AgentOverrideSchema = v.object({
 
 const MicodeFeaturesSchema = v.object({
   mindmodelInjection: v.optional(v.boolean()),
+  /** Set false when context7 is already provided by another tool or proxy. */
+  context7: v.optional(v.boolean()),
 });
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { Plugin } from "@opencode-ai/plugin";
 import type { AgentConfig, McpLocalConfig } from "@opencode-ai/sdk";
 
 import { agents, PRIMARY_AGENT_NAME } from "@/agents";
-import { loadMicodeConfig, loadModelContextLimits, mergeAgentConfigs } from "@/config-loader";
+import { loadMicodeConfig, loadModelContextLimits, type MicodeFeatures, mergeAgentConfigs } from "@/config-loader";
 import {
   createArtifactAutoIndexHook,
   createAutoCompactHook,
@@ -54,27 +54,47 @@ function detectThinkKeyword(text: string): boolean {
   return THINK_KEYWORDS.some((pattern) => pattern.test(text));
 }
 
-// MCP server configurations
-const MCP_SERVERS: Record<string, McpLocalConfig> = {
-  context7: {
-    type: "local",
-    command: ["npx", "-y", "@upstash/context7-mcp@latest"],
-  },
-};
+/**
+ * MCP servers the plugin offers. Every one is opt-out: context7 through
+ * features.context7, the research servers through their API keys. Callers
+ * spread the result *under* the host config so a user's own entry always wins.
+ */
+export function buildMcpServers(features?: MicodeFeatures): Record<string, McpLocalConfig> {
+  const servers: Record<string, McpLocalConfig> = {};
 
-// Environment-gated research MCP servers
-if (process.env.PERPLEXITY_API_KEY) {
-  MCP_SERVERS.perplexity = {
-    type: "local",
-    command: ["npx", "-y", "@anthropic/mcp-perplexity"],
-  };
+  if (features?.context7 !== false) {
+    servers.context7 = {
+      type: "local",
+      command: ["npx", "-y", "@upstash/context7-mcp@latest"],
+    };
+  }
+
+  if (process.env.PERPLEXITY_API_KEY) {
+    servers.perplexity = {
+      type: "local",
+      command: ["npx", "-y", "@anthropic/mcp-perplexity"],
+    };
+  }
+
+  if (process.env.FIRECRAWL_API_KEY) {
+    servers.firecrawl = {
+      type: "local",
+      command: ["npx", "-y", "firecrawl-mcp"],
+    };
+  }
+
+  return servers;
 }
 
-if (process.env.FIRECRAWL_API_KEY) {
-  MCP_SERVERS.firecrawl = {
-    type: "local",
-    command: ["npx", "-y", "firecrawl-mcp"],
-  };
+/**
+ * Layer the plugin's MCP servers beneath whatever the host already declares,
+ * so a user entry of the same name replaces the bundled one outright.
+ */
+export function mergeMcpServers<T>(
+  hostServers: Record<string, T> | undefined,
+  features?: MicodeFeatures,
+): Record<string, T | McpLocalConfig> {
+  return { ...buildMcpServers(features), ...hostServers };
 }
 
 const PLUGIN_COMMANDS = {
@@ -329,11 +349,7 @@ const OpenCodeConfigPlugin: Plugin = async (ctx) => {
         [PRIMARY_AGENT_NAME]: pluginAgents[PRIMARY_AGENT_NAME],
       };
 
-      // Add MCP servers (plugin servers override defaults)
-      config.mcp = {
-        ...config.mcp,
-        ...MCP_SERVERS,
-      };
+      config.mcp = mergeMcpServers(config.mcp, userConfig?.features);
 
       // Add commands
       config.command = { ...config.command, ...PLUGIN_COMMANDS };

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -716,6 +716,14 @@ describe("JSONC parsing support", () => {
       expect(config?.features?.mindmodelInjection).toBe(true);
       expect(config?.compactionThreshold).toBe(0.4);
     });
+
+    it("should carry features.context7 through to the loaded config", async () => {
+      writeFileSync(join(testConfigDir, "micode.json"), JSON.stringify({ features: { context7: false } }));
+
+      const config = await loadMicodeConfig(testConfigDir);
+
+      expect(config?.features?.context7).toBe(false);
+    });
   });
 
   describe("loadModelContextLimits with JSONC", () => {

--- a/tests/mcp-servers.test.ts
+++ b/tests/mcp-servers.test.ts
@@ -1,0 +1,79 @@
+// tests/mcp-servers.test.ts
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { buildMcpServers, mergeMcpServers } from "../src/index";
+
+const RESEARCH_KEYS = ["PERPLEXITY_API_KEY", "FIRECRAWL_API_KEY"] as const;
+
+describe("buildMcpServers", () => {
+  let originalKeys: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    originalKeys = Object.fromEntries(RESEARCH_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of RESEARCH_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of RESEARCH_KEYS) {
+      const value = originalKeys[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("registers context7 by default", () => {
+    expect(Object.keys(buildMcpServers())).toEqual(["context7"]);
+    expect(buildMcpServers().context7.command).toContain("@upstash/context7-mcp@latest");
+  });
+
+  it("omits context7 when the feature is disabled", () => {
+    expect(buildMcpServers({ context7: false })).toEqual({});
+  });
+
+  it("keeps context7 when the feature is unset or explicitly enabled", () => {
+    expect(Object.keys(buildMcpServers({}))).toContain("context7");
+    expect(Object.keys(buildMcpServers({ context7: true }))).toContain("context7");
+  });
+
+  it("gates the research servers behind their API keys", () => {
+    expect(Object.keys(buildMcpServers())).not.toContain("perplexity");
+
+    process.env.PERPLEXITY_API_KEY = "test-key";
+    process.env.FIRECRAWL_API_KEY = "test-key";
+    expect(Object.keys(buildMcpServers())).toEqual(["context7", "perplexity", "firecrawl"]);
+  });
+
+  it("leaves every server disableable, so nothing is forced on a host", () => {
+    // Regression guard for #49: context7 used to be unconditional and was
+    // spread over the host config, so it could be neither replaced nor removed.
+    expect(buildMcpServers({ context7: false })).toEqual({});
+  });
+});
+
+describe("mergeMcpServers", () => {
+  const hostContext7 = { type: "local" as const, command: ["my-own-context7"] };
+
+  it("lets a host entry of the same name replace the bundled server", () => {
+    const merged = mergeMcpServers({ context7: hostContext7 });
+    expect(merged.context7.command).toEqual(["my-own-context7"]);
+  });
+
+  it("keeps host-only servers alongside the bundled ones", () => {
+    const custom = { type: "local" as const, command: ["something-else"] };
+    const merged = mergeMcpServers({ custom });
+
+    expect(merged.custom).toEqual(custom);
+    expect(Object.keys(merged)).toContain("context7");
+  });
+
+  it("registers the bundled servers when the host declares none", () => {
+    expect(Object.keys(mergeMcpServers(undefined))).toEqual(["context7"]);
+  });
+
+  it("drops context7 entirely when disabled and unclaimed by the host", () => {
+    expect(mergeMcpServers({}, { context7: false })).toEqual({});
+  });
+});


### PR DESCRIPTION
Closes #49.

## Problem

The reporter already gets context7 from a code-mode proxy and asked to turn ours off. They couldn't, for two compounding reasons.

`context7` was registered unconditionally, and the merge put the plugin's servers **on top** of the host's:

```ts
config.mcp = { ...config.mcp, ...MCP_SERVERS };
```

So `context7` won every key collision. Declaring your own `context7` in `opencode.json` did nothing, because the plugin's entry overwrote it a moment later. There was no removal path and no override path.

What makes this clearly an oversight rather than a decision: the two servers sitting immediately beside it in the same file are both opt-in, gated on `PERPLEXITY_API_KEY` and `FIRECRAWL_API_KEY`. context7 was the only one forced on.

## Fix

Two independent changes, either of which solves the reporter's case:

1. **`features.context7: false`** removes it outright.
2. **Host config now wins.** Plugin servers are layered *beneath* `config.mcp`, so an entry you declare in `opencode.json` replaces the bundled one and you can point context7 wherever you like.

```jsonc
{
  "features": {
    "context7": false
  }
}
```

The merge moved into `mergeMcpServers`, a pure function, so precedence is testable without standing up the whole plugin.

## Also: the README documented the wrong compaction default

Unrelated, found while checking #62. `README.md` said `Default: 0.5`; `auto-compact.ts` falls back to `config.compaction.threshold`, which is **0.7**. Anyone tuning that value from the docs was working from a wrong number. Corrected, and `features.context7` documented alongside it.

## Verification

**488 tests pass** (was 478). Both new behaviours are mutation-checked rather than assumed:

- reverting `context7` to unconditional → 2 tests fail
- reverting the merge order to plugin-wins → the precedence test fails

`buildMcpServers` and `mergeMcpServers` are also covered for the research-server API-key gating and for host-only entries surviving the merge. Bundle loads clean under both Bun and Node.