### PR TITLE
fix: keep mindmodel constraint files on the .md extension (#58)

### DIFF
--- a/src/agents/mindmodel/constraint-writer.ts
+++ b/src/agents/mindmodel/constraint-writer.ts
@@ -112,11 +112,13 @@ categories:
 </manifest-format>
 
 <rules>
+- manifest.yaml is the ONLY YAML file. Every constraint file is Markdown and MUST end in .md
+- Never write a constraint file as stack/frontend.yaml or patterns/logging.yaml; those are .md
 - Only create files for categories that have content
 - Skip empty categories (e.g., no frontend = no stack/frontend.md)
 - Keep each file focused and concise
 - Include 2-3 examples and 1-2 anti-patterns per file
-- Ensure manifest.yaml lists all created files
+- Ensure manifest.yaml lists all created files, each path ending in .md
 </rules>`;
 
 export const constraintWriterAgent: AgentConfig = {

--- a/src/mindmodel/loader.ts
+++ b/src/mindmodel/loader.ts
@@ -7,6 +7,8 @@ import { extractErrorMessage } from "@/utils/errors";
 import { log } from "@/utils/logger";
 import { type MindmodelManifest, parseManifest } from "./types";
 
+const MARKDOWN_EXTENSION = ".md";
+
 export interface LoadedMindmodel {
   readonly directory: string;
   readonly manifest: MindmodelManifest;
@@ -16,6 +18,17 @@ export interface LoadedExample {
   readonly path: string;
   readonly description: string;
   readonly content: string;
+}
+
+// Constraint files are Markdown; manifest.yaml is the only YAML in .mindmodel.
+// Weaker models sometimes emit stack/frontend.yaml and friends, which loads but
+// leaves the directory inconsistent, so say so rather than failing the manifest.
+function warnNonMarkdownCategories(manifest: MindmodelManifest): void {
+  const wrongExtension = manifest.categories.map((c) => c.path).filter((path) => !path.endsWith(MARKDOWN_EXTENSION));
+
+  if (wrongExtension.length > 0) {
+    log.warn("mindmodel", `Constraint files must end in ${MARKDOWN_EXTENSION}: ${wrongExtension.join(", ")}`);
+  }
 }
 
 export async function loadMindmodel(projectDir: string): Promise<LoadedMindmodel | null> {
@@ -32,6 +45,7 @@ export async function loadMindmodel(projectDir: string): Promise<LoadedMindmodel
   try {
     const manifestContent = await readFile(manifestPath, "utf-8");
     const manifest = parseManifest(manifestContent);
+    warnNonMarkdownCategories(manifest);
 
     return {
       directory: mindmodelDir,

--- a/tests/mindmodel/loader.test.ts
+++ b/tests/mindmodel/loader.test.ts
@@ -133,4 +133,52 @@ categories:
     expect(examples[0].path).toBe("components/button.md");
     expect(logs.warn).toEqual(["[mindmodel] Failed to load example: components/missing.md"]);
   });
+
+  it("names the constraint files that are not markdown", async () => {
+    const mindmodelDir = join(testDir, ".mindmodel");
+    mkdirSync(join(mindmodelDir, "stack"), { recursive: true });
+
+    writeFileSync(
+      join(mindmodelDir, "manifest.yaml"),
+      `
+name: test
+version: 1
+categories:
+  - path: stack/frontend.yaml
+    description: Frontend patterns
+  - path: stack/backend.md
+    description: Backend patterns
+  - path: patterns/logging.yml
+    description: Logging patterns
+`,
+    );
+
+    const mindmodel = await loadMindmodel(testDir);
+
+    // A wrong extension is worth reporting but must not discard the manifest.
+    expect(mindmodel).not.toBeNull();
+    expect(mindmodel?.manifest.categories).toHaveLength(3);
+    expect(logs.warn).toEqual([
+      "[mindmodel] Constraint files must end in .md: stack/frontend.yaml, patterns/logging.yml",
+    ]);
+  });
+
+  it("stays quiet when every constraint file is markdown", async () => {
+    const mindmodelDir = join(testDir, ".mindmodel");
+    mkdirSync(join(mindmodelDir, "stack"), { recursive: true });
+
+    writeFileSync(
+      join(mindmodelDir, "manifest.yaml"),
+      `
+name: test
+version: 1
+categories:
+  - path: stack/frontend.md
+    description: Frontend patterns
+`,
+    );
+
+    expect(await loadMindmodel(testDir)).not.toBeNull();
+    expect(logs.warn).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #58.

## Problem

`/mindmodel` generated constraint files ending in `.yaml` instead of `.md`. Reported against qwen3.6 35b.

The generator prompt was not actually wrong, which is why this is easy to miss: its `<output-structure>` block lists every constraint file with a `.md` extension and only `manifest.yaml` as YAML. But the rule was only ever *implied* by that listing. Sitting right beside it is a `<manifest-format>` block containing a `yaml` code fence, and a weaker model reads that as licence to write the whole directory as YAML.

## Fix

Two parts, because prompt wording alone is not verifiable.

**Say the rule outright.** `<rules>` now states that `manifest.yaml` is the only YAML file and names the exact mistake, rather than leaving it to be inferred from a directory diagram.

**Report it when it happens anyway.** The loader now names any category path that is not `.md`:

```
[mindmodel] Constraint files must end in .md: stack/frontend.yaml, patterns/logging.yml
```

Deliberately a warning, not a parse failure. A wrong extension leaves the directory inconsistent rather than broken, since the file still loads by its declared path. Failing the manifest would discard an otherwise usable mindmodel over a naming problem, and the project's own guidance is to treat parse issues as non-fatal where possible.

## Verification

**490 tests pass** (was 488). Two new cases: one asserting the warning names only the offending paths while the manifest still loads with all three categories intact, one asserting silence when every path is `.md`.

Mutation-checked: removing the `warnNonMarkdownCategories` call fails the first test.

The prompt change itself is not testable here, since it depends on model behaviour. The loader warning is what makes a bad generation visible rather than silent.