### PR TITLE
fix: export only the plugin factory from the plugin entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from "@opencode-ai/plugin";
-import type { AgentConfig, McpLocalConfig } from "@opencode-ai/sdk";
 
 import { agents, PRIMARY_AGENT_NAME } from "@/agents";
-import { loadMicodeConfig, loadModelContextLimits, type MicodeFeatures, mergeAgentConfigs } from "@/config-loader";
+import { loadMicodeConfig, loadModelContextLimits, mergeAgentConfigs } from "@/config-loader";
 import {
   createArtifactAutoIndexHook,
   createAutoCompactHook,
@@ -20,6 +19,7 @@ import {
   getFileOps,
   warnUnknownAgents,
 } from "@/hooks";
+import { mergeMcpServers, mergePluginAgents } from "@/plugin-config";
 import {
   artifact_search,
   ast_grep_replace,
@@ -54,49 +54,6 @@ function detectThinkKeyword(text: string): boolean {
   return THINK_KEYWORDS.some((pattern) => pattern.test(text));
 }
 
-/**
- * MCP servers the plugin offers. Every one is opt-out: context7 through
- * features.context7, the research servers through their API keys. Callers
- * spread the result *under* the host config so a user's own entry always wins.
- */
-export function buildMcpServers(features?: MicodeFeatures): Record<string, McpLocalConfig> {
-  const servers: Record<string, McpLocalConfig> = {};
-
-  if (features?.context7 !== false) {
-    servers.context7 = {
-      type: "local",
-      command: ["npx", "-y", "@upstash/context7-mcp@latest"],
-    };
-  }
-
-  if (process.env.PERPLEXITY_API_KEY) {
-    servers.perplexity = {
-      type: "local",
-      command: ["npx", "-y", "@anthropic/mcp-perplexity"],
-    };
-  }
-
-  if (process.env.FIRECRAWL_API_KEY) {
-    servers.firecrawl = {
-      type: "local",
-      command: ["npx", "-y", "firecrawl-mcp"],
-    };
-  }
-
-  return servers;
-}
-
-/**
- * Layer the plugin's MCP servers beneath whatever the host already declares,
- * so a user entry of the same name replaces the bundled one outright.
- */
-export function mergeMcpServers<T>(
-  hostServers: Record<string, T> | undefined,
-  features?: MicodeFeatures,
-): Record<string, T | McpLocalConfig> {
-  return { ...buildMcpServers(features), ...hostServers };
-}
-
 const PLUGIN_COMMANDS = {
   init: {
     description: "Initialize project with ARCHITECTURE.md and CODE_STYLE.md",
@@ -125,22 +82,6 @@ function extractTextFromParts(parts: Array<{ type: string; text?: string }>): st
     .filter((p) => p.type === "text" && "text" in p)
     .map((p) => (p as { text: string }).text)
     .join("");
-}
-
-export function mergePluginAgentConfig(existingAgent: AgentConfig | undefined, pluginAgent: AgentConfig): AgentConfig {
-  return {
-    ...existingAgent,
-    ...pluginAgent,
-  };
-}
-
-export function mergePluginAgents(
-  existingAgents: Record<string, AgentConfig | undefined> | undefined,
-  pluginAgents: Record<string, AgentConfig>,
-): Record<string, AgentConfig> {
-  return Object.fromEntries(
-    Object.entries(pluginAgents).map(([name, agent]) => [name, mergePluginAgentConfig(existingAgents?.[name], agent)]),
-  );
 }
 
 // eslint-disable-next-line max-lines-per-function

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,0 +1,69 @@
+// src/plugin-config.ts
+// Config shaping the plugin applies to the host's opencode config.
+//
+// These live outside the plugin entry point on purpose: opencode calls every
+// exported function in a plugin module as a plugin factory and installs each
+// return value as hooks, so the entry point must export the plugin alone.
+
+import type { AgentConfig, McpLocalConfig } from "@opencode-ai/sdk";
+
+import type { MicodeFeatures } from "@/config-loader";
+
+/**
+ * MCP servers the plugin offers. Every one is opt-out: context7 through
+ * features.context7, the research servers through their API keys. Callers
+ * spread the result *under* the host config so a user's own entry always wins.
+ */
+export function buildMcpServers(features?: MicodeFeatures): Record<string, McpLocalConfig> {
+  const servers: Record<string, McpLocalConfig> = {};
+
+  if (features?.context7 !== false) {
+    servers.context7 = {
+      type: "local",
+      command: ["npx", "-y", "@upstash/context7-mcp@latest"],
+    };
+  }
+
+  if (process.env.PERPLEXITY_API_KEY) {
+    servers.perplexity = {
+      type: "local",
+      command: ["npx", "-y", "@anthropic/mcp-perplexity"],
+    };
+  }
+
+  if (process.env.FIRECRAWL_API_KEY) {
+    servers.firecrawl = {
+      type: "local",
+      command: ["npx", "-y", "firecrawl-mcp"],
+    };
+  }
+
+  return servers;
+}
+
+/**
+ * Layer the plugin's MCP servers beneath whatever the host already declares,
+ * so a user entry of the same name replaces the bundled one outright.
+ */
+export function mergeMcpServers<T>(
+  hostServers: Record<string, T> | undefined,
+  features?: MicodeFeatures,
+): Record<string, T | McpLocalConfig> {
+  return { ...buildMcpServers(features), ...hostServers };
+}
+
+export function mergePluginAgentConfig(existingAgent: AgentConfig | undefined, pluginAgent: AgentConfig): AgentConfig {
+  return {
+    ...existingAgent,
+    ...pluginAgent,
+  };
+}
+
+export function mergePluginAgents(
+  existingAgents: Record<string, AgentConfig | undefined> | undefined,
+  pluginAgents: Record<string, AgentConfig>,
+): Record<string, AgentConfig> {
+  return Object.fromEntries(
+    Object.entries(pluginAgents).map(([name, agent]) => [name, mergePluginAgentConfig(existingAgents?.[name], agent)]),
+  );
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 
-import { mergePluginAgents } from "../src/index";
+import { mergePluginAgents } from "../src/plugin-config";
 
 describe("mergePluginAgents", () => {
   it("preserves user iteration limits from existing OpenCode agent config", () => {
@@ -79,5 +79,22 @@ describe("index.ts commands", () => {
     const mindmodelMatch = source.match(/mindmodel:\s*\{[^}]*agent:\s*["']([^"']+)["']/);
     expect(mindmodelMatch).not.toBeNull();
     expect(mindmodelMatch?.[1]).toBe("mm-orchestrator");
+  });
+});
+
+// opencode calls every exported function in a plugin module as a plugin factory
+// and treats each return value as a hooks object. A stray helper export is
+// therefore never harmless: it either throws and kills registration, or returns
+// something nonsensical that opencode installs as hooks. Which one happens to
+// win depends on alphabetical sort order of the module namespace, so the only
+// safe surface is the plugin itself.
+describe("plugin module surface", () => {
+  it("exports the plugin factory and nothing else callable", async () => {
+    const surface: Record<string, unknown> = await import("../src/index");
+    const callable = Object.entries(surface)
+      .filter(([, value]) => typeof value === "function")
+      .map(([name]) => name);
+
+    expect(callable).toEqual(["OpenCodeConfigPlugin"]);
   });
 });

--- a/tests/mcp-servers.test.ts
+++ b/tests/mcp-servers.test.ts
@@ -1,7 +1,7 @@
 // tests/mcp-servers.test.ts
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { buildMcpServers, mergeMcpServers } from "../src/index";
+import { buildMcpServers, mergeMcpServers } from "../src/plugin-config";
 
 const RESEARCH_KEYS = ["PERPLEXITY_API_KEY", "FIRECRAWL_API_KEY"] as const;
 


### PR DESCRIPTION
Found while researching an e2e harness: micode currently logs a plugin load error on every opencode start, and only registers its hooks by luck.

## What opencode actually does

It calls **every exported function** in a plugin module as a plugin factory, and installs each return value as hooks:

```js
function rk($) { let Q=[]; for (let Y of Object.values($)) { Q.push(ok(Y)) } return Q }
async function tk($,Z,Q) { for (let J of rk($.mod)) Q.push(await J(Z, $.options)) }
```

`src/index.ts` exported four helpers alongside the plugin. Invoked as `(input, options)`, `mergePluginAgents` receives `options === undefined` and throws:

```
level=ERROR message="failed to load plugin" path=file:///.../dist/index.js
  error="Object.entries requires that input parameter not be null or undefined"
```

opencode swallows that error and still exits `0`, so nothing surfaced it.

## Why it worked anyway, and why that is not reassuring

ESM namespace keys are sorted alphabetically, not by declaration order. `OpenCodeConfigPlugin` starts with a capital `O` (charCode 79), which sorts ahead of lowercase `b` (98), so the real plugin registered its hooks before the throw.

Rename that export to something lowercase, or add any export sorting in `A`–`N`, and **every micode hook disappears silently with a clean exit code**.

Verified against the shipped bundle before the fix:

```
OpenCodeConfigPlugin    OK
buildMcpServers         OK
mergeMcpServers         OK
mergePluginAgentConfig  OK
mergePluginAgents       THREW: Object.entries requires that input parameter not be null or undefined
```

Note the non-throwing helpers were not harmless either. `buildMcpServers(ctx, undefined)` returns a map of MCP servers, which opencode would then install as a hooks object.

## Fix

Move the four helpers to `src/plugin-config.ts`. The entry point now exports the plugin alone:

```
$ bun -e "import('./dist/index.js').then(m => console.log(Object.keys(m)))"
[ "OpenCodeConfigPlugin" ]
```

Tests import them from their new home; no behaviour changed.

## Verification

**489 tests pass.** A new guard asserts the module's callable surface is exactly `["OpenCodeConfigPlugin"]`, which is the invariant rather than a proxy for it, since a helper that returns rather than throws is equally wrong.

Mutation-checked: re-exporting a single helper from `src/index.ts` fails the guard.

The guard deliberately does not invoke the factories. Doing so loads the PTY library and probes for `btca`, which leaks output into the reporter and takes 20x longer.