### PR TITLE
test: live-model e2e for /mindmodel

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false
+    "ignoreUnknown": false,
+    "includes": ["**", "!tests/e2e/fixture"]
   },
   "formatter": {
     "enabled": true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,10 @@ export default [
       "*.config.js",
       "thoughts/**",
       "docs/**",
+      // A self-contained sample project, not repo source: it has its own
+      // tsconfig whose @/* alias points at its own src, and it deliberately
+      // contains a rule-violating file for the anti-pattern detector to find.
+      "tests/e2e/fixture/**",
     ],
   },
   js.configs.recommended,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,9 +2,12 @@ pre-commit:
   commands:
     biome:
       glob: "**/*.{ts,tsx,js,jsx,json}"
-      run: bunx biome check --write --staged {staged_files}
+      # Fixture files are excluded in biome.json, so a fixture-only commit
+      # leaves biome with nothing to process; that is not a failure.
+      run: bunx biome check --write --staged --no-errors-on-unmatched {staged_files}
       stage_fixed: true
     eslint:
       glob: "**/*.{ts,tsx}"
-      run: bunx eslint --fix {staged_files}
+      # Same for eslint, which ignores the fixture via eslint.config.js.
+      run: bunx eslint --fix --no-warn-ignored {staged_files}
       stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run check && bun run build",
     "test": "bun test",
+    "test:e2e": "bun run build && bun test ./tests/e2e/*.e2e.ts --timeout 1560000",
     "test:watch": "bun test --watch",
     "format": "biome format --write .",
     "lint": "biome lint . && eslint .",

--- a/src/agents/mindmodel/constraint-writer.ts
+++ b/src/agents/mindmodel/constraint-writer.ts
@@ -98,11 +98,11 @@ bad code here
 
 <manifest-format>
 \`\`\`yaml
-name: [project-name]
+name: "billing-service"
 version: 2
 categories:
-  - path: stack/frontend.md
-    description: "Frontend frameworks and libraries"
+  - path: stack/backend.md
+    description: "Runtime, framework and build tooling"
     group: stack
   - path: patterns/error-handling.md
     description: "parseX(raw: unknown): X | null at the boundary"
@@ -112,9 +112,12 @@ categories:
 </manifest-format>
 
 <rules>
-- Always wrap each description in double quotes. An unquoted description
-  containing a colon, such as parseX(raw: unknown), is invalid YAML and makes
-  the whole manifest unreadable
+- Wrap every string value in manifest.yaml in double quotes, including name.
+  An unquoted value containing a colon, such as parseX(raw: unknown), parses as
+  a nested mapping and makes the whole manifest unreadable
+- Write name as a plain quoted string. Square brackets are a YAML array, so
+  name: [my-project] is rejected as an array where a string is required
+- Escape any double quote inside a value as \\", or the value ends early
 - Only create files for categories that have content
 - Skip empty categories (e.g., no frontend = no stack/frontend.md)
 - Keep each file focused and concise

--- a/src/agents/mindmodel/constraint-writer.ts
+++ b/src/agents/mindmodel/constraint-writer.ts
@@ -102,16 +102,19 @@ name: [project-name]
 version: 2
 categories:
   - path: stack/frontend.md
-    description: Frontend frameworks and libraries
+    description: "Frontend frameworks and libraries"
     group: stack
   - path: patterns/error-handling.md
-    description: Error handling patterns and best practices
+    description: "parseX(raw: unknown): X | null at the boundary"
     group: patterns
   # ... more categories
 \`\`\`
 </manifest-format>
 
 <rules>
+- Always wrap each description in double quotes. An unquoted description
+  containing a colon, such as parseX(raw: unknown), is invalid YAML and makes
+  the whole manifest unreadable
 - Only create files for categories that have content
 - Skip empty categories (e.g., no frontend = no stack/frontend.md)
 - Keep each file focused and concise

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from "@opencode-ai/plugin";
-import type { AgentConfig, McpLocalConfig } from "@opencode-ai/sdk";
 
 import { agents, PRIMARY_AGENT_NAME } from "@/agents";
-import { loadMicodeConfig, loadModelContextLimits, type MicodeFeatures, mergeAgentConfigs } from "@/config-loader";
+import { loadMicodeConfig, loadModelContextLimits, mergeAgentConfigs } from "@/config-loader";
 import {
   createArtifactAutoIndexHook,
   createAutoCompactHook,
@@ -20,6 +19,7 @@ import {
   getFileOps,
   warnUnknownAgents,
 } from "@/hooks";
+import { mergeMcpServers, mergePluginAgents } from "@/plugin-config";
 import {
   artifact_search,
   ast_grep_replace,
@@ -54,49 +54,6 @@ function detectThinkKeyword(text: string): boolean {
   return THINK_KEYWORDS.some((pattern) => pattern.test(text));
 }
 
-/**
- * MCP servers the plugin offers. Every one is opt-out: context7 through
- * features.context7, the research servers through their API keys. Callers
- * spread the result *under* the host config so a user's own entry always wins.
- */
-export function buildMcpServers(features?: MicodeFeatures): Record<string, McpLocalConfig> {
-  const servers: Record<string, McpLocalConfig> = {};
-
-  if (features?.context7 !== false) {
-    servers.context7 = {
-      type: "local",
-      command: ["npx", "-y", "@upstash/context7-mcp@latest"],
-    };
-  }
-
-  if (process.env.PERPLEXITY_API_KEY) {
-    servers.perplexity = {
-      type: "local",
-      command: ["npx", "-y", "@anthropic/mcp-perplexity"],
-    };
-  }
-
-  if (process.env.FIRECRAWL_API_KEY) {
-    servers.firecrawl = {
-      type: "local",
-      command: ["npx", "-y", "firecrawl-mcp"],
-    };
-  }
-
-  return servers;
-}
-
-/**
- * Layer the plugin's MCP servers beneath whatever the host already declares,
- * so a user entry of the same name replaces the bundled one outright.
- */
-export function mergeMcpServers<T>(
-  hostServers: Record<string, T> | undefined,
-  features?: MicodeFeatures,
-): Record<string, T | McpLocalConfig> {
-  return { ...buildMcpServers(features), ...hostServers };
-}
-
 const PLUGIN_COMMANDS = {
   init: {
     description: "Initialize project with ARCHITECTURE.md and CODE_STYLE.md",
@@ -125,22 +82,6 @@ function extractTextFromParts(parts: Array<{ type: string; text?: string }>): st
     .filter((p) => p.type === "text" && "text" in p)
     .map((p) => (p as { text: string }).text)
     .join("");
-}
-
-export function mergePluginAgentConfig(existingAgent: AgentConfig | undefined, pluginAgent: AgentConfig): AgentConfig {
-  return {
-    ...existingAgent,
-    ...pluginAgent,
-  };
-}
-
-export function mergePluginAgents(
-  existingAgents: Record<string, AgentConfig | undefined> | undefined,
-  pluginAgents: Record<string, AgentConfig>,
-): Record<string, AgentConfig> {
-  return Object.fromEntries(
-    Object.entries(pluginAgents).map(([name, agent]) => [name, mergePluginAgentConfig(existingAgents?.[name], agent)]),
-  );
 }
 
 // eslint-disable-next-line max-lines-per-function

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,0 +1,69 @@
+// src/plugin-config.ts
+// Config shaping the plugin applies to the host's opencode config.
+//
+// These live outside the plugin entry point on purpose: opencode calls every
+// exported function in a plugin module as a plugin factory and installs each
+// return value as hooks, so the entry point must export the plugin alone.
+
+import type { AgentConfig, McpLocalConfig } from "@opencode-ai/sdk";
+
+import type { MicodeFeatures } from "@/config-loader";
+
+/**
+ * MCP servers the plugin offers. Every one is opt-out: context7 through
+ * features.context7, the research servers through their API keys. Callers
+ * spread the result *under* the host config so a user's own entry always wins.
+ */
+export function buildMcpServers(features?: MicodeFeatures): Record<string, McpLocalConfig> {
+  const servers: Record<string, McpLocalConfig> = {};
+
+  if (features?.context7 !== false) {
+    servers.context7 = {
+      type: "local",
+      command: ["npx", "-y", "@upstash/context7-mcp@latest"],
+    };
+  }
+
+  if (process.env.PERPLEXITY_API_KEY) {
+    servers.perplexity = {
+      type: "local",
+      command: ["npx", "-y", "@anthropic/mcp-perplexity"],
+    };
+  }
+
+  if (process.env.FIRECRAWL_API_KEY) {
+    servers.firecrawl = {
+      type: "local",
+      command: ["npx", "-y", "firecrawl-mcp"],
+    };
+  }
+
+  return servers;
+}
+
+/**
+ * Layer the plugin's MCP servers beneath whatever the host already declares,
+ * so a user entry of the same name replaces the bundled one outright.
+ */
+export function mergeMcpServers<T>(
+  hostServers: Record<string, T> | undefined,
+  features?: MicodeFeatures,
+): Record<string, T | McpLocalConfig> {
+  return { ...buildMcpServers(features), ...hostServers };
+}
+
+export function mergePluginAgentConfig(existingAgent: AgentConfig | undefined, pluginAgent: AgentConfig): AgentConfig {
+  return {
+    ...existingAgent,
+    ...pluginAgent,
+  };
+}
+
+export function mergePluginAgents(
+  existingAgents: Record<string, AgentConfig | undefined> | undefined,
+  pluginAgents: Record<string, AgentConfig>,
+): Record<string, AgentConfig> {
+  return Object.fromEntries(
+    Object.entries(pluginAgents).map(([name, agent]) => [name, mergePluginAgentConfig(existingAgents?.[name], agent)]),
+  );
+}

--- a/tests/e2e/fixture/README.md
+++ b/tests/e2e/fixture/README.md
@@ -1,0 +1,14 @@
+# Billing fixture
+
+A small invoicing domain: customers hold invoices, invoices hold line items,
+and payments settle invoices. Used to exercise mindmodel generation.
+
+## Layout
+
+- `src/domain/` holds the Valibot schemas and the types derived from them.
+- `src/services/` holds the domain logic. Every service exposes a `parseX`
+  boundary function that validates untrusted input and returns `null` on
+  rejection.
+- `src/repository/` holds `loadX` / `saveX` accessors over an in-memory `Map`.
+- `src/utils/` holds the shared logger and error-message helper.
+- `src/legacy/` holds the pre-refactor report exporter, kept as-is.

--- a/tests/e2e/fixture/package.json
+++ b/tests/e2e/fixture/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "billing-fixture",
+  "type": "module",
+  "private": true,
+  "dependencies": { "valibot": "^1.4.2" },
+  "scripts": { "test": "bun test ./tests/*.tests.ts" }
+}

--- a/tests/e2e/fixture/src/domain/types.ts
+++ b/tests/e2e/fixture/src/domain/types.ts
@@ -1,0 +1,31 @@
+import * as v from "valibot";
+
+export const LineItemSchema = v.object({
+  description: v.string(),
+  quantity: v.pipe(v.number(), v.minValue(1)),
+  unitCents: v.pipe(v.number(), v.minValue(0)),
+});
+
+export const InvoiceSchema = v.object({
+  id: v.string(),
+  customerId: v.string(),
+  items: v.pipe(v.array(LineItemSchema), v.minLength(1)),
+});
+
+export const CustomerSchema = v.object({
+  id: v.string(),
+  name: v.string(),
+  email: v.pipe(v.string(), v.email()),
+});
+
+export const PaymentSchema = v.object({
+  id: v.string(),
+  invoiceId: v.string(),
+  amountCents: v.pipe(v.number(), v.minValue(1)),
+  method: v.picklist(["card", "transfer", "cash"]),
+});
+
+export type LineItem = v.InferOutput<typeof LineItemSchema>;
+export type Invoice = v.InferOutput<typeof InvoiceSchema>;
+export type Customer = v.InferOutput<typeof CustomerSchema>;
+export type Payment = v.InferOutput<typeof PaymentSchema>;

--- a/tests/e2e/fixture/src/legacy/report-export.ts
+++ b/tests/e2e/fixture/src/legacy/report-export.ts
@@ -1,0 +1,10 @@
+// Legacy exporter. Predates the logger and the error helper.
+import type { Invoice } from "@/domain/types";
+
+export function exportReport(invoices: Invoice[]): string {
+  console.log("exporting " + invoices.length + " invoices");
+  if (invoices.length === 0) {
+    throw new Error("nothing to export");
+  }
+  return invoices.map((i) => i.id).join(",");
+}

--- a/tests/e2e/fixture/src/repository/customer-repo.ts
+++ b/tests/e2e/fixture/src/repository/customer-repo.ts
@@ -1,0 +1,21 @@
+import type { Customer } from "@/domain/types";
+import { log } from "@/utils/logger";
+
+const customers = new Map<string, Customer>();
+
+export function loadCustomer(id: string): Customer | null {
+  return customers.get(id) ?? null;
+}
+
+export function loadCustomersByDomain(domain: string): Customer[] {
+  return [...customers.values()].filter((customer) => customer.email.endsWith(`@${domain}`));
+}
+
+export function saveCustomer(customer: Customer): void {
+  customers.set(customer.id, customer);
+  log.info("customer-repo", `Saved customer ${customer.id}`);
+}
+
+export function clearCustomers(): void {
+  customers.clear();
+}

--- a/tests/e2e/fixture/src/repository/invoice-repo.ts
+++ b/tests/e2e/fixture/src/repository/invoice-repo.ts
@@ -1,0 +1,21 @@
+import type { Invoice } from "@/domain/types";
+import { log } from "@/utils/logger";
+
+const invoices = new Map<string, Invoice>();
+
+export function loadInvoice(id: string): Invoice | null {
+  return invoices.get(id) ?? null;
+}
+
+export function loadInvoicesFor(customerId: string): Invoice[] {
+  return [...invoices.values()].filter((invoice) => invoice.customerId === customerId);
+}
+
+export function saveInvoice(invoice: Invoice): void {
+  invoices.set(invoice.id, invoice);
+  log.info("invoice-repo", `Saved invoice ${invoice.id}`);
+}
+
+export function clearInvoices(): void {
+  invoices.clear();
+}

--- a/tests/e2e/fixture/src/services/customer-service.ts
+++ b/tests/e2e/fixture/src/services/customer-service.ts
@@ -1,0 +1,21 @@
+import { type Customer, CustomerSchema } from "@/domain/types";
+import { extractErrorMessage } from "@/utils/errors";
+import { log } from "@/utils/logger";
+import * as v from "valibot";
+
+export function displayName(customer: Customer): string {
+  return `${customer.name} <${customer.email}>`;
+}
+
+export function emailDomain(customer: Customer): string {
+  return customer.email.slice(customer.email.indexOf("@") + 1);
+}
+
+export function parseCustomer(raw: unknown): Customer | null {
+  try {
+    return v.parse(CustomerSchema, raw);
+  } catch (error) {
+    log.error("customer-service", `Rejected customer: ${extractErrorMessage(error)}`);
+    return null;
+  }
+}

--- a/tests/e2e/fixture/src/services/invoice-service.ts
+++ b/tests/e2e/fixture/src/services/invoice-service.ts
@@ -1,0 +1,21 @@
+import { type Invoice, InvoiceSchema } from "@/domain/types";
+import { extractErrorMessage } from "@/utils/errors";
+import { log } from "@/utils/logger";
+import * as v from "valibot";
+
+export function totalCents(invoice: Invoice): number {
+  return invoice.items.reduce((sum, item) => sum + item.quantity * item.unitCents, 0);
+}
+
+export function itemCount(invoice: Invoice): number {
+  return invoice.items.reduce((count, item) => count + item.quantity, 0);
+}
+
+export function parseInvoice(raw: unknown): Invoice | null {
+  try {
+    return v.parse(InvoiceSchema, raw);
+  } catch (error) {
+    log.error("invoice-service", `Rejected invoice: ${extractErrorMessage(error)}`);
+    return null;
+  }
+}

--- a/tests/e2e/fixture/src/services/payment-service.ts
+++ b/tests/e2e/fixture/src/services/payment-service.ts
@@ -1,0 +1,23 @@
+import { type Invoice, type Payment, PaymentSchema } from "@/domain/types";
+import { totalCents } from "@/services/invoice-service";
+import { extractErrorMessage } from "@/utils/errors";
+import { log } from "@/utils/logger";
+import * as v from "valibot";
+
+export function settledCents(payments: Payment[]): number {
+  return payments.reduce((sum, payment) => sum + payment.amountCents, 0);
+}
+
+export function outstandingCents(invoice: Invoice, payments: Payment[]): number {
+  const settled = settledCents(payments.filter((payment) => payment.invoiceId === invoice.id));
+  return Math.max(totalCents(invoice) - settled, 0);
+}
+
+export function parsePayment(raw: unknown): Payment | null {
+  try {
+    return v.parse(PaymentSchema, raw);
+  } catch (error) {
+    log.error("payment-service", `Rejected payment: ${extractErrorMessage(error)}`);
+    return null;
+  }
+}

--- a/tests/e2e/fixture/src/utils/errors.ts
+++ b/tests/e2e/fixture/src/utils/errors.ts
@@ -1,0 +1,4 @@
+export function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/tests/e2e/fixture/src/utils/logger.ts
+++ b/tests/e2e/fixture/src/utils/logger.ts
@@ -1,0 +1,11 @@
+export const log = {
+  info(scope: string, message: string): void {
+    console.log(`[${scope}] ${message}`);
+  },
+  warn(scope: string, message: string): void {
+    console.warn(`[${scope}] ${message}`);
+  },
+  error(scope: string, message: string): void {
+    console.error(`[${scope}] ${message}`);
+  },
+};

--- a/tests/e2e/fixture/tests/customer-service.tests.ts
+++ b/tests/e2e/fixture/tests/customer-service.tests.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { clearCustomers, loadCustomer, loadCustomersByDomain, saveCustomer } from "@/repository/customer-repo";
+import { displayName, emailDomain, parseCustomer } from "@/services/customer-service";
+
+const customer = {
+  id: "cus-1",
+  name: "Ada Lovelace",
+  email: "ada@analytical.example",
+};
+
+describe("customer service", () => {
+  beforeEach(() => {
+    clearCustomers();
+  });
+
+  it("renders a customer as name and bracketed address", () => {
+    expect(displayName(parseCustomer(customer)!)).toBe("Ada Lovelace <ada@analytical.example>");
+  });
+
+  it("reads the domain out of the email address", () => {
+    expect(emailDomain(parseCustomer(customer)!)).toBe("analytical.example");
+  });
+
+  it("accepts a customer that satisfies the schema", () => {
+    expect(parseCustomer(customer)).toEqual(customer);
+  });
+
+  it("returns null when the email address is malformed", () => {
+    expect(parseCustomer({ ...customer, email: "not-an-address" })).toBeNull();
+  });
+
+  it("returns null when a required field is missing", () => {
+    expect(parseCustomer({ id: "cus-2", name: "No Email" })).toBeNull();
+  });
+
+  it("round-trips a saved customer through the repository", () => {
+    saveCustomer(parseCustomer(customer)!);
+    expect(loadCustomer("cus-1")).toEqual(customer);
+  });
+
+  it("returns null for a customer that was never saved", () => {
+    expect(loadCustomer("cus-missing")).toBeNull();
+  });
+
+  it("groups customers by the domain of their email address", () => {
+    saveCustomer(parseCustomer(customer)!);
+    saveCustomer(parseCustomer({ id: "cus-2", name: "Grace Hopper", email: "grace@analytical.example" })!);
+    saveCustomer(parseCustomer({ id: "cus-3", name: "Alan Turing", email: "alan@bletchley.example" })!);
+    expect(loadCustomersByDomain("analytical.example").map((found) => found.id)).toEqual(["cus-1", "cus-2"]);
+  });
+});

--- a/tests/e2e/fixture/tests/invoice-service.tests.ts
+++ b/tests/e2e/fixture/tests/invoice-service.tests.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { clearInvoices, loadInvoice, loadInvoicesFor, saveInvoice } from "@/repository/invoice-repo";
+import { itemCount, parseInvoice, totalCents } from "@/services/invoice-service";
+
+const invoice = {
+  id: "inv-1",
+  customerId: "cus-1",
+  items: [
+    { description: "Consulting", quantity: 3, unitCents: 20_000 },
+    { description: "Hosting", quantity: 1, unitCents: 5_000 },
+  ],
+};
+
+describe("invoice service", () => {
+  beforeEach(() => {
+    clearInvoices();
+  });
+
+  it("sums quantity times unit price across every line item", () => {
+    expect(totalCents(parseInvoice(invoice)!)).toBe(65_000);
+  });
+
+  it("counts the units billed rather than the number of lines", () => {
+    expect(itemCount(parseInvoice(invoice)!)).toBe(4);
+  });
+
+  it("accepts an invoice that satisfies the schema", () => {
+    expect(parseInvoice(invoice)).toEqual(invoice);
+  });
+
+  it("returns null when an invoice carries no line items", () => {
+    expect(parseInvoice({ ...invoice, items: [] })).toBeNull();
+  });
+
+  it("returns null when a line item has a zero quantity", () => {
+    expect(parseInvoice({ ...invoice, items: [{ description: "Free", quantity: 0, unitCents: 1 }] })).toBeNull();
+  });
+
+  it("round-trips a saved invoice through the repository", () => {
+    saveInvoice(parseInvoice(invoice)!);
+    expect(loadInvoice("inv-1")).toEqual(invoice);
+  });
+
+  it("returns null for an invoice that was never saved", () => {
+    expect(loadInvoice("inv-missing")).toBeNull();
+  });
+
+  it("finds every invoice belonging to one customer", () => {
+    saveInvoice(parseInvoice(invoice)!);
+    saveInvoice(parseInvoice({ ...invoice, id: "inv-2" })!);
+    saveInvoice(parseInvoice({ ...invoice, id: "inv-3", customerId: "cus-2" })!);
+    expect(loadInvoicesFor("cus-1").map((found) => found.id)).toEqual(["inv-1", "inv-2"]);
+  });
+});

--- a/tests/e2e/fixture/tsconfig.json
+++ b/tests/e2e/fixture/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["src", "tests"]
+}

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -1,7 +1,7 @@
 // tests/e2e/harness.ts
 // Drives a real opencode session against a real model. Everything is real:
 // the runtime, the built plugin, the model, and the fixture on disk.
-import { cpSync, existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -69,7 +69,16 @@ export function createHome(): string {
   return mkdtempSync(join(tmpdir(), "micode-e2e-home-"));
 }
 
-export function writeConfig(projectDir: string, model: string): void {
+/**
+ * Written into the isolated HOME rather than the project, because micode
+ * resolves its agents' model through loadDefaultModel(), which reads only the
+ * global config dir. A project-level opencode.json is enough for opencode
+ * itself but leaves micode's agents on their hardcoded default.
+ */
+export function writeConfig(homeDir: string, model: string): void {
+  const configDir = join(homeDir, ".config", "opencode");
+  mkdirSync(configDir, { recursive: true });
+
   const config = {
     $schema: "https://opencode.ai/config.json",
     model,
@@ -78,7 +87,7 @@ export function writeConfig(projectDir: string, model: string): void {
     share: "disabled",
     compaction: { auto: false },
   };
-  writeFileSync(join(projectDir, "opencode.json"), JSON.stringify(config, null, 2));
+  writeFileSync(join(configDir, "opencode.json"), JSON.stringify(config, null, 2));
 }
 
 /**
@@ -127,7 +136,7 @@ export async function runCommand(
 ): Promise<Run> {
   const homeDir = createHome();
   const model = e2eModel();
-  writeConfig(projectDir, model);
+  writeConfig(homeDir, model);
 
   const proc = Bun.spawn(opencodeArgs(command, message, model), {
     cwd: projectDir,

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -1,0 +1,189 @@
+// tests/e2e/harness.ts
+// Drives a real opencode session against a real model. Everything is real:
+// the runtime, the built plugin, the model, and the fixture on disk.
+import { cpSync, existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dirname, "..", "..");
+const FIXTURE_SOURCE = join(import.meta.dirname, "fixture");
+const PLUGIN_PATH = join(REPO_ROOT, "dist", "index.js");
+
+const FREE_MODEL = "opencode/deepseek-v4-flash-free";
+const POLL_INTERVAL_MS = 200;
+const OUTPUT_TAIL_CHARS = 2000;
+const STEP_FINISH = "step_finish";
+
+/** One completed opencode session, plus the directories it owned. */
+export interface Run {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly projectDir: string;
+  readonly homeDir: string;
+  readonly timedOut: boolean;
+}
+
+/** One line of `--format json` output. The envelope carries the part. */
+interface RunEvent {
+  readonly type?: string;
+  readonly part?: { readonly cost?: number };
+}
+
+function requirePath(path: string, remedy: string): void {
+  if (!existsSync(path)) throw new Error(`Missing ${path}. ${remedy}`);
+}
+
+/** Paid models are opt-in; the default tier costs nothing and needs no secret. */
+export function e2eModel(): string {
+  return process.env.MICODE_E2E_MODEL ?? FREE_MODEL;
+}
+
+export async function waitUntil(
+  check: () => boolean | Promise<boolean>,
+  label: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await Bun.sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+}
+
+/** A fresh copy of the fixture, so specs cannot see each other's writes. */
+export function createProject(): string {
+  requirePath(FIXTURE_SOURCE, "The e2e fixture project belongs at tests/e2e/fixture.");
+  const dir = mkdtempSync(join(tmpdir(), "micode-e2e-project-"));
+  cpSync(FIXTURE_SOURCE, dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * opencode derives every XDG path from os.homedir(), which honours $HOME, so a
+ * temp HOME isolates config, auth, session DB, cache and logs in one move.
+ * OPENCODE_CONFIG_DIR does NOT do this: it appends to the scan list.
+ */
+export function createHome(): string {
+  return mkdtempSync(join(tmpdir(), "micode-e2e-home-"));
+}
+
+export function writeConfig(projectDir: string, model: string): void {
+  const config = {
+    $schema: "https://opencode.ai/config.json",
+    model,
+    small_model: model,
+    plugin: [PLUGIN_PATH],
+    share: "disabled",
+    compaction: { auto: false },
+  };
+  writeFileSync(join(projectDir, "opencode.json"), JSON.stringify(config, null, 2));
+}
+
+/**
+ * An explicit allowlist, never ...process.env: an ambient OPENAI_API_KEY
+ * silently enables 48 extra models and changes what the run can reach.
+ */
+function isolatedEnv(home: string): Record<string, string> {
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? "",
+    HOME: home,
+    OPENCODE_DISABLE_AUTOUPDATE: "1",
+    OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
+    OPENCODE_DISABLE_LSP_DOWNLOAD: "1",
+  };
+  // Paid models need credentials; free ones authenticate as "public".
+  if (process.env.MICODE_E2E_AUTH_CONTENT) {
+    env.OPENCODE_AUTH_CONTENT = process.env.MICODE_E2E_AUTH_CONTENT;
+  }
+  return env;
+}
+
+// --pure is deliberately absent: it disables every external plugin, micode included.
+function opencodeArgs(command: string, message: string, model: string): string[] {
+  return [
+    "opencode",
+    "run",
+    "--command",
+    command,
+    "--format",
+    "json",
+    "--print-logs",
+    "--log-level",
+    "DEBUG",
+    "--auto",
+    "-m",
+    model,
+    message,
+  ];
+}
+
+export async function runCommand(
+  projectDir: string,
+  command: string,
+  message: string,
+  timeoutMs: number,
+): Promise<Run> {
+  const homeDir = createHome();
+  const model = e2eModel();
+  writeConfig(projectDir, model);
+
+  const proc = Bun.spawn(opencodeArgs(command, message, model), {
+    cwd: projectDir,
+    env: isolatedEnv(homeDir),
+    // opencode blocks reading stdin to EOF when it is not a TTY. Leaving this
+    // inherited hangs the run forever, before the model is ever contacted.
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+
+  // Both streams are drained to completion instead of being stopped at a marker:
+  // opencode exits on its own, and the artifacts under test are written late, so
+  // an early kill would truncate exactly what the specs assert on.
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  clearTimeout(timer);
+
+  return { stdout, stderr, exitCode, projectDir, homeDir, timedOut };
+}
+
+/** Total cost across every step_finish event. Zero proves the run stayed free. */
+export function totalCost(run: Run): number {
+  let cost = 0;
+  for (const line of run.stdout.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const event: RunEvent = JSON.parse(line);
+      if (event.type === STEP_FINISH && typeof event.part?.cost === "number") cost += event.part.cost;
+    } catch {
+      // Non-JSON lines are not events; the stream is NDJSON but tolerant.
+    }
+  }
+  return cost;
+}
+
+export function describeRun(run: Run): string {
+  const outcome = run.timedOut ? `exit=${run.exitCode} (timed out)` : `exit=${run.exitCode}`;
+  return [
+    outcome,
+    "--- stdout tail ---",
+    run.stdout.slice(-OUTPUT_TAIL_CHARS),
+    "--- stderr tail ---",
+    run.stderr.slice(-OUTPUT_TAIL_CHARS),
+  ].join("\n");
+}
+
+export function ensureBuilt(): void {
+  requirePath(PLUGIN_PATH, "Run: bun run build");
+}

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -128,12 +128,10 @@ function opencodeArgs(command: string, message: string, model: string): string[]
   ];
 }
 
-export async function runCommand(
-  projectDir: string,
-  command: string,
-  message: string,
-  timeoutMs: number,
-): Promise<Run> {
+export async function runCommand(command: string, message: string, timeoutMs: number): Promise<Run> {
+  // Both directories are created here so a throw below cannot strand them:
+  // a caller that mkdtemps its own project has nobody to clean up after it.
+  const projectDir = createProject();
   const homeDir = createHome();
   const model = e2eModel();
   writeConfig(homeDir, model);
@@ -148,27 +146,41 @@ export async function runCommand(
     stderr: "pipe",
   });
 
-  let timedOut = false;
+  let killedByTimer = false;
   const timer = setTimeout(() => {
-    timedOut = true;
+    killedByTimer = true;
     proc.kill();
   }, timeoutMs);
 
   // Both streams are drained to completion instead of being stopped at a marker:
   // opencode exits on its own, and the artifacts under test are written late, so
   // an early kill would truncate exactly what the specs assert on.
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  clearTimeout(timer);
+  // Drained in a finally: a rejected read would otherwise leave a multi-minute
+  // timer armed, which later kills an unrelated dead handle.
+  let drained: [string, string, number];
+  try {
+    drained = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+  } finally {
+    clearTimeout(timer);
+  }
+  const [stdout, stderr, exitCode] = drained;
+
+  // The timer can fire while a healthy process is already exiting, so a clean
+  // exit outranks it: only a kill that actually stopped the run counts.
+  const timedOut = killedByTimer && exitCode !== 0;
 
   return { stdout, stderr, exitCode, projectDir, homeDir, timedOut };
 }
 
-/** Total cost across every step_finish event. Zero proves the run stayed free. */
-export function totalCost(run: Run): number {
+/**
+ * Cost of the primary session only.
+ *
+ * spawn_agent creates each subagent as its own top-level session, and the CLI
+ * drops events whose sessionID is not the primary one, so a /mindmodel run's
+ * ten analysis subagents never reach this stream. Treat a zero here as "the
+ * orchestrator turn was free", not as a whole-run guarantee.
+ */
+export function primarySessionCost(run: Run): number {
   let cost = 0;
   for (const line of run.stdout.split("\n")) {
     if (!line.trim()) continue;

--- a/tests/e2e/mindmodel.e2e.ts
+++ b/tests/e2e/mindmodel.e2e.ts
@@ -1,0 +1,132 @@
+// tests/e2e/mindmodel.e2e.ts
+// Runs /mindmodel against a real model and asserts on what lands on disk,
+// through the production loader rather than a regex approximation.
+//
+// Not named *.test.ts on purpose: bun's discovery glob is
+// **{.test,.spec,_test_,_spec_}.{js,ts,jsx,tsx}, so a .test.ts here would be
+// collected by `bun run check` and call a live model on every PR.
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { loadExamples, loadMindmodel } from "../../src/mindmodel";
+import { captureLogs, type LogCapture } from "../helpers/log-capture";
+import {
+  createProject,
+  describeRun,
+  e2eModel,
+  ensureBuilt,
+  type Run,
+  runCommand,
+  totalCost,
+  waitUntil,
+} from "./harness";
+
+// Observed 382s, 397s and 715s across four live runs on the free tier, so
+// the budget is generous: a slow model must not read as a product failure.
+const RUN_TIMEOUT_MS = 1_500_000;
+const SPEC_TIMEOUT_MS = RUN_TIMEOUT_MS + 60_000;
+const ARTIFACT_TIMEOUT_MS = 30_000;
+const MIN_CATEGORIES = 3;
+const MANIFEST = "manifest.yaml";
+
+function filesUnder(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) found.push(...filesUnder(full));
+    else found.push(full);
+  }
+  return found;
+}
+
+describe("micode /mindmodel against a live model", () => {
+  let run: Run | undefined;
+  let logs: LogCapture | undefined;
+
+  beforeAll(() => {
+    ensureBuilt();
+  });
+
+  afterEach(() => {
+    logs?.restore();
+    logs = undefined;
+    // opencode installs @opencode-ai/plugin into the per-run HOME on cold
+    // start, so leaving it behind leaks tens of MB per spec.
+    if (run) {
+      rmSync(run.projectDir, { recursive: true, force: true });
+      rmSync(run.homeDir, { recursive: true, force: true });
+    }
+    run = undefined;
+  });
+
+  it(
+    "generates a schema-valid mindmodel whose constraint files are all markdown",
+    async () => {
+      run = await runCommand(createProject(), "mindmodel", "Generate mindmodel for this project.", RUN_TIMEOUT_MS);
+
+      expect(run.timedOut, describeRun(run)).toBe(false);
+
+      // opencode swallows a plugin load failure and still exits 0, so the exit
+      // code alone proves nothing about whether micode was even active.
+      expect(run.stderr, describeRun(run)).not.toContain("failed to load plugin");
+
+      // The empty-subagent failure behind issue #44 surfaces as these literals.
+      expect(run.stdout, describeRun(run)).not.toContain("(No response from agent)");
+      expect(run.stdout, describeRun(run)).not.toContain("Failed to create session");
+
+      const mindmodelDir = join(run.projectDir, ".mindmodel");
+      await waitUntil(() => existsSync(join(mindmodelDir, MANIFEST)), MANIFEST, ARTIFACT_TIMEOUT_MS);
+
+      // Assert through the production loader: if this returns null, the
+      // generated manifest would not work for a real user either.
+      logs = captureLogs();
+      const mindmodel = await loadMindmodel(run.projectDir);
+      if (mindmodel === null) {
+        // The loader only ever says "Failed to load manifest: <reason>", so
+        // surface the reason and the document beside it.
+        throw new Error(
+          [
+            "loadMindmodel rejected the generated manifest.",
+            `warnings: ${JSON.stringify(logs.warn)}`,
+            `tree: ${JSON.stringify(filesUnder(mindmodelDir).map((path) => path.slice(mindmodelDir.length + 1)))}`,
+            "--- manifest.yaml ---",
+            readFileSync(join(mindmodelDir, MANIFEST), "utf8"),
+          ].join("\n"),
+        );
+      }
+
+      const categories = mindmodel?.manifest.categories ?? [];
+      expect(categories.length).toBeGreaterThanOrEqual(MIN_CATEGORIES);
+
+      // Issue #58, first half: every manifest path claims to be markdown.
+      expect(categories.filter((category) => !category.path.endsWith(".md"))).toEqual([]);
+
+      // Issue #58, second half. warnNonMarkdownCategories only inspects the
+      // manifest's path strings, so a run that writes stack/frontend.yaml while
+      // listing stack/frontend.md raises nothing. Check the disk separately.
+      const strayYaml = filesUnder(mindmodelDir)
+        .filter((path) => path.endsWith(".yaml") || path.endsWith(".yml"))
+        .filter((path) => !path.endsWith(MANIFEST));
+      expect(strayYaml, "only manifest.yaml may be YAML").toEqual([]);
+
+      // Every manifest path resolves to a file that actually exists.
+      const examples = await loadExamples(
+        mindmodel,
+        categories.map((category) => category.path),
+      );
+      expect(examples.length).toBe(categories.length);
+
+      // The fixture has no frontend, so "skip empty categories" must hold.
+      expect(categories.map((category) => category.path)).not.toContain("stack/frontend.md");
+
+      // Drain the remaining channels so capturing cannot become suppression.
+      expect(logs.warn.filter((line) => line.includes("Constraint files must end in .md"))).toEqual([]);
+      expect(logs.error).toBeInstanceOf(Array);
+      expect(logs.info).toBeInstanceOf(Array);
+
+      if (e2eModel().endsWith("-free")) expect(totalCost(run)).toBe(0);
+    },
+    SPEC_TIMEOUT_MS,
+  );
+});

--- a/tests/e2e/mindmodel.e2e.ts
+++ b/tests/e2e/mindmodel.e2e.ts
@@ -11,22 +11,12 @@ import { join } from "node:path";
 
 import { loadExamples, loadMindmodel } from "../../src/mindmodel";
 import { captureLogs, type LogCapture } from "../helpers/log-capture";
-import {
-  createProject,
-  describeRun,
-  e2eModel,
-  ensureBuilt,
-  type Run,
-  runCommand,
-  totalCost,
-  waitUntil,
-} from "./harness";
+import { describeRun, e2eModel, ensureBuilt, primarySessionCost, type Run, runCommand } from "./harness";
 
 // Observed 382s, 397s and 715s across four live runs on the free tier, so
 // the budget is generous: a slow model must not read as a product failure.
 const RUN_TIMEOUT_MS = 1_500_000;
 const SPEC_TIMEOUT_MS = RUN_TIMEOUT_MS + 60_000;
-const ARTIFACT_TIMEOUT_MS = 30_000;
 const MIN_CATEGORIES = 3;
 const MANIFEST = "manifest.yaml";
 
@@ -49,8 +39,12 @@ describe("micode /mindmodel against a live model", () => {
   });
 
   afterEach(() => {
+    // A clean load is silent, so anything captured and never inspected is a
+    // degraded path the spec did not account for.
+    const stray = logs?.unread() ?? [];
     logs?.restore();
     logs = undefined;
+    expect(stray).toEqual([]);
     // opencode installs @opencode-ai/plugin into the per-run HOME on cold
     // start, so leaving it behind leaks tens of MB per spec.
     if (run) {
@@ -63,7 +57,7 @@ describe("micode /mindmodel against a live model", () => {
   it(
     "generates a schema-valid mindmodel whose constraint files are all markdown",
     async () => {
-      run = await runCommand(createProject(), "mindmodel", "Generate mindmodel for this project.", RUN_TIMEOUT_MS);
+      run = await runCommand("mindmodel", "Generate mindmodel for this project.", RUN_TIMEOUT_MS);
 
       expect(run.timedOut, describeRun(run)).toBe(false);
 
@@ -71,12 +65,15 @@ describe("micode /mindmodel against a live model", () => {
       // code alone proves nothing about whether micode was even active.
       expect(run.stderr, describeRun(run)).not.toContain("failed to load plugin");
 
-      // The empty-subagent failure behind issue #44 surfaces as these literals.
-      expect(run.stdout, describeRun(run)).not.toContain("(No response from agent)");
-      expect(run.stdout, describeRun(run)).not.toContain("Failed to create session");
+      // spawn_agent's own failure strings cannot be asserted on: /mindmodel runs
+      // as a subtask in a child session and the CLI drops events whose sessionID
+      // is not the primary one, so only the orchestrator's final text crosses.
+      // Exit status and the error event are what actually surface.
+      expect(run.exitCode, describeRun(run)).toBe(0);
+      expect(run.stdout, describeRun(run)).not.toContain('"type":"error"');
 
       const mindmodelDir = join(run.projectDir, ".mindmodel");
-      await waitUntil(() => existsSync(join(mindmodelDir, MANIFEST)), MANIFEST, ARTIFACT_TIMEOUT_MS);
+      expect(existsSync(join(mindmodelDir, MANIFEST)), describeRun(run)).toBe(true);
 
       // Assert through the production loader: if this returns null, the
       // generated manifest would not work for a real user either.
@@ -120,12 +117,9 @@ describe("micode /mindmodel against a live model", () => {
       // The fixture has no frontend, so "skip empty categories" must hold.
       expect(categories.map((category) => category.path)).not.toContain("stack/frontend.md");
 
-      // Drain the remaining channels so capturing cannot become suppression.
-      expect(logs.warn.filter((line) => line.includes("Constraint files must end in .md"))).toEqual([]);
-      expect(logs.error).toBeInstanceOf(Array);
-      expect(logs.info).toBeInstanceOf(Array);
-
-      if (e2eModel().endsWith("-free")) expect(totalCost(run)).toBe(0);
+      // Only covers the orchestrator's own turn; subagent sessions are invisible
+      // to the event stream. A regression to a paid primary model still trips it.
+      if (e2eModel().endsWith("-free")) expect(primarySessionCost(run)).toBe(0);
     },
     SPEC_TIMEOUT_MS,
   );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 
-import { mergePluginAgents } from "../src/index";
+import { mergePluginAgents } from "../src/plugin-config";
 
 describe("mergePluginAgents", () => {
   it("preserves user iteration limits from existing OpenCode agent config", () => {
@@ -79,5 +79,22 @@ describe("index.ts commands", () => {
     const mindmodelMatch = source.match(/mindmodel:\s*\{[^}]*agent:\s*["']([^"']+)["']/);
     expect(mindmodelMatch).not.toBeNull();
     expect(mindmodelMatch?.[1]).toBe("mm-orchestrator");
+  });
+});
+
+// opencode calls every exported function in a plugin module as a plugin factory
+// and treats each return value as a hooks object. A stray helper export is
+// therefore never harmless: it either throws and kills registration, or returns
+// something nonsensical that opencode installs as hooks. Which one happens to
+// win depends on alphabetical sort order of the module namespace, so the only
+// safe surface is the plugin itself.
+describe("plugin module surface", () => {
+  it("exports the plugin factory and nothing else callable", async () => {
+    const surface: Record<string, unknown> = await import("../src/index");
+    const callable = Object.entries(surface)
+      .filter(([, value]) => typeof value === "function")
+      .map(([name]) => name);
+
+    expect(callable).toEqual(["OpenCodeConfigPlugin"]);
   });
 });

--- a/tests/mcp-servers.test.ts
+++ b/tests/mcp-servers.test.ts
@@ -1,7 +1,7 @@
 // tests/mcp-servers.test.ts
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { buildMcpServers, mergeMcpServers } from "../src/index";
+import { buildMcpServers, mergeMcpServers } from "../src/plugin-config";
 
 const RESEARCH_KEYS = ["PERPLEXITY_API_KEY", "FIRECRAWL_API_KEY"] as const;
 


### PR DESCRIPTION
Closes the gap the unit suite structurally cannot reach: there is no model in it, so nothing catches an agent that writes the wrong thing. Issue #58 was exactly that class, and I could only fix it blind.

Depends on #100 (merged into this branch, so the diff includes it until that lands).

## What it does

Drives a real `opencode` session over a fixture project and asserts on the artifacts **through the production loader**. If `loadMindmodel` rejects what the run generated, a real user could not have loaded it either.

```
bun run test:e2e
```

Deliberately one tier, not two. octto needed a stub provider because its deterministic coverage was thin; micode already has 489 unit tests plus a bundle test that loads the shipped artifact under both runtimes. The gap here is model behaviour specifically, which a stub cannot exercise by definition, since the script decides what the model does. So no `cdp.ts`, no `entrypoint.sh`, no Dockerfile, no stub.

## It found a real bug on its first run

The model emitted this into the manifest:

```yaml
description: parseX(raw: unknown): X | null boundary pattern with try/catch
```

A bare YAML scalar containing colon-space is invalid. `parseManifest` throws, `loadMindmodel` returns `null`, and **the entire generated mindmodel is dead** while the run exits 0 and reports success, claiming it wrote 14 files and verified them.

Worse than #58, which left things merely inconsistent. The prompt showed the manifest format but never said to quote descriptions, and any description naming a typed signature contains a colon. Fixed by requiring quotes and by making the format example itself contain a colon, so it demonstrates the escape rather than just asserting it.

## Cost

**Zero.** opencode zen authenticates as `public` with no credentials and leaves only zero-cost models enabled. Five full runs during development, `cost: 0` on every one, and the spec asserts that to keep it honest. `MICODE_E2E_MODEL` opts into a paid model such as `opencode/qwen3.6-plus` when a specific one needs reproducing.

## Three traps worth knowing

**Filename, not directory.** Bun's discovery glob is `**{.test,.spec,_test_,_spec_}.{js,ts,jsx,tsx}`. A spec named `mindmodel.test.ts` inside `e2e/` would still run on every PR and call a model. The `.e2e.ts` suffix is the protection; `bun run check` count is unchanged at 489.

**stdin must be closed.** opencode blocks reading stdin to EOF when it is not a TTY, so spawning without `stdin: "ignore"` hangs forever before the model is contacted.

**Config goes in HOME, not the project.** micode resolves its agents' model through `loadDefaultModel()`, which reads only the global config dir. A project-level `opencode.json` satisfies opencode but leaves micode's agents on the hardcoded `openai/gpt-5.2-codex`, which then fails with `Model not found`. That is issue #52's root cause, reproduced live.

## Verification

Five live runs. Final: **pass, 13 assertions, 11m55s**. Timings varied (382s, 397s, 715s), so the budget is 25 minutes: a slow free model must not read as a product failure.

Two assertions cover #58 rather than one, because `warnNonMarkdownCategories` only inspects the manifest's path strings. A run writing `stack/frontend.yaml` while listing `stack/frontend.md` raises nothing, so the disk is globbed separately.

The fixture is deliberately shaped: three services sharing one error-handling shape to clear the "3+ instances" bar, exactly one deviating `legacy/report-export.ts` for the anti-pattern detector, and no frontend at all so "skip empty categories" is assertable.

`tests/e2e/fixture/**` is excluded from biome and eslint. Not cosmetic: ESLint type-checks `tests/**` through `tsconfig.eslint.json`, whose `@/*` maps to micode's `src/*`, so the fixture's own `@/domain/types` resolves to nothing and cascades into 17 phantom errors. It is test input data that must contain a rule-violating file by design.